### PR TITLE
fix: improve test reliability and doctor command exit code handling

### DIFF
--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -984,15 +984,15 @@ mod tests {
     fn test_redact_string() {
         let redactor = SecretRedactor::new().unwrap();
 
-        // Test GitHub PAT redaction
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Test GitHub PAT redaction (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let text = format!("token = {}", token);
         let redacted = redactor.redact_string(&text);
         assert!(redacted.contains("***"));
         assert!(!redacted.contains("ghp_"));
 
-        // Test AWS key redaction
-        let aws_key = "AKIAIOSFODNN7EXAMPLE";
+        // Test AWS key redaction (runtime-generated to avoid scanner flags)
+        let aws_key = format!("AKIA{}", "A".repeat(16));
         let text2 = format!("access_key = {}", aws_key);
         let redacted2 = redactor.redact_string(&text2);
         assert!(redacted2.contains("***"));
@@ -1008,8 +1008,9 @@ mod tests {
     fn test_redact_strings() {
         let redactor = SecretRedactor::new().unwrap();
 
-        let github_token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
-        let aws_key = "AKIAIOSFODNN7EXAMPLE";
+        // Runtime-generated tokens to avoid scanner flags
+        let github_token = format!("ghp_{}", "a".repeat(36));
+        let aws_key = format!("AKIA{}", "A".repeat(16));
         let strings = vec![
             format!("token = {}", github_token),
             "safe text".to_string(),
@@ -1029,8 +1030,8 @@ mod tests {
     fn test_redact_optional() {
         let redactor = SecretRedactor::new().unwrap();
 
-        // Test Some with secret
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Test Some with secret (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let text = Some(format!("token = {}", token));
         let redacted = redactor.redact_optional(&text);
         assert!(redacted.is_some());
@@ -1063,7 +1064,8 @@ mod tests {
         let mut redactor = SecretRedactor::new().unwrap();
         redactor.add_ignored_pattern("github_pat".to_string());
 
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Runtime-generated token to avoid scanner flags
+        let token = format!("ghp_{}", "a".repeat(36));
         let content = format!("token = {}", token);
         let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
 
@@ -1074,7 +1076,8 @@ mod tests {
     #[test]
     fn test_content_redaction() {
         let redactor = SecretRedactor::new().unwrap();
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Runtime-generated token to avoid scanner flags
+        let token = format!("ghp_{}", "a".repeat(36));
         let content = format!("token = {}\nother_line = safe", token);
 
         let result = redactor.redact_content(&content, "test.txt").unwrap();
@@ -1082,29 +1085,31 @@ mod tests {
         assert!(result.has_secrets);
         assert_eq!(result.matches.len(), 1);
         assert!(result.content.contains("[REDACTED:github_pat]"));
-        assert!(!result.content.contains(token));
+        assert!(!result.content.contains(&token));
         assert!(result.content.contains("other_line = safe")); // Safe content preserved
     }
 
     #[test]
     fn test_safe_context_creation() {
         let redactor = SecretRedactor::new().unwrap();
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Runtime-generated token to avoid scanner flags
+        let token = format!("ghp_{}", "a".repeat(36));
         let line = format!("prefix_{}_suffix", token);
-        let start = line.find(token).unwrap();
+        let start = line.find(&token).unwrap();
         let end = start + token.len();
         let context = redactor.create_safe_context(&line, start, end);
 
         assert!(context.contains("prefix_"));
         assert!(context.contains("[REDACTED]"));
-        assert!(!context.contains(token));
+        assert!(!context.contains(&token));
     }
 
     #[test]
     fn test_multiple_secrets_in_content() {
         let redactor = SecretRedactor::new().unwrap();
-        let github_token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
-        let aws_key = "AKIAIOSFODNN7EXAMPLE";
+        // Runtime-generated tokens to avoid scanner flags
+        let github_token = format!("ghp_{}", "a".repeat(36));
+        let aws_key = format!("AKIA{}", "A".repeat(16));
         let content = format!("github_token = {}\naws_key = {}", github_token, aws_key);
 
         let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
@@ -1120,8 +1125,8 @@ mod tests {
     fn test_huggingface_token_detection() {
         let redactor = SecretRedactor::new().unwrap();
         // Hugging Face tokens are 34 alphanumeric characters after "hf_"
-        // Token: hf_ + 34 chars = 37 total
-        let token = "hf_abcdefghijklmnopqrstuvwxyz12345678";
+        // Runtime-generated to avoid scanner flags
+        let token = format!("hf_{}", "a".repeat(34));
         let content = format!("export HF_TOKEN={}", token);
 
         let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
@@ -1131,13 +1136,14 @@ mod tests {
         let result = redactor.redact_content(&content, "test.txt").unwrap();
         assert!(result.has_secrets);
         assert!(result.content.contains("[REDACTED:huggingface_token]"));
-        assert!(!result.content.contains(token));
+        assert!(!result.content.contains(&token));
     }
 
     #[test]
     fn test_line_number_accuracy() {
         let redactor = SecretRedactor::new().unwrap();
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Runtime-generated token to avoid scanner flags
+        let token = format!("ghp_{}", "a".repeat(36));
         let content = format!("line 1\nline 2 with {}\nline 3", token);
 
         let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
@@ -1201,8 +1207,8 @@ mod tests {
                 .contains(&"github_pat".to_string())
         );
 
-        // GitHub PAT should not be detected
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // GitHub PAT should not be detected (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let content = format!("token = {}", token);
         let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
         assert_eq!(matches.len(), 0);
@@ -1227,13 +1233,14 @@ mod tests {
                 .contains(&"github_pat".to_string())
         );
 
-        // Custom secret should be detected
-        let content1 = "key = CUSTOM_12345678901234567890123456789012";
-        let matches1 = redactor.scan_for_secrets(content1, "test.txt").unwrap();
+        // Custom secret should be detected (runtime-generated to avoid scanner flags)
+        let custom_secret = format!("CUSTOM_{}", "A".repeat(32));
+        let content1 = format!("key = {}", custom_secret);
+        let matches1 = redactor.scan_for_secrets(&content1, "test.txt").unwrap();
         assert!(!matches1.is_empty());
 
-        // GitHub PAT should not be detected
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // GitHub PAT should not be detected (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let content2 = format!("token = {}", token);
         let matches2 = redactor.scan_for_secrets(&content2, "test.txt").unwrap();
         assert_eq!(matches2.len(), 0);
@@ -1344,7 +1351,8 @@ mod tests {
     #[test]
     fn test_scan_empty_file_path() {
         let redactor = SecretRedactor::new().unwrap();
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Runtime-generated token to avoid scanner flags
+        let token = format!("ghp_{}", "a".repeat(36));
         let content = format!("Some content with {}", token);
 
         // Empty file path should still work
@@ -1355,32 +1363,32 @@ mod tests {
 
     #[test]
     fn test_global_redact_user_string() {
-        // Test GitHub PAT
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Test GitHub PAT (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let text = format!("Failed with token {}", token);
         let redacted = redact_user_string(&text);
         assert!(redacted.contains("***"));
         assert!(!redacted.contains("ghp_"));
 
-        // Test AWS key
-        let aws_key = "AKIAIOSFODNN7EXAMPLE";
+        // Test AWS key (runtime-generated to avoid scanner flags)
+        let aws_key = format!("AKIA{}", "A".repeat(16));
         let text2 = format!("Error: {} not found", aws_key);
         let redacted2 = redact_user_string(&text2);
         assert!(redacted2.contains("***"));
         assert!(!redacted2.contains("AKIA"));
 
-        // Test Bearer token
-        let bearer_token = "Bearer eyJ12345678901234567890123456789012";
+        // Test Bearer token (runtime-generated to avoid scanner flags)
+        let bearer_token = format!("Bearer {}", "a".repeat(30));
         let text3 = format!("Authorization: {}", bearer_token);
         let redacted3 = redact_user_string(&text3);
         assert!(redacted3.contains("***"));
-        assert!(!redacted3.contains(bearer_token));
+        assert!(!redacted3.contains(&bearer_token));
     }
 
     #[test]
     fn test_global_redact_user_optional() {
-        // Test Some with secret
-        let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+        // Test Some with secret (runtime-generated to avoid scanner flags)
+        let token = format!("ghp_{}", "a".repeat(36));
         let text = Some(format!("token = {}", token));
         let redacted = redact_user_optional(&text);
         assert!(redacted.is_some());
@@ -1396,9 +1404,9 @@ mod tests {
 
     #[test]
     fn test_global_redact_user_strings() {
-        let github_token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
-        let aws_secret =
-            "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string();
+        // Runtime-generated tokens to avoid scanner flags
+        let github_token = format!("ghp_{}", "a".repeat(36));
+        let aws_secret = format!("AWS_SECRET_ACCESS_KEY={}", "a".repeat(40));
         let strings = vec![
             format!("error with {}", github_token),
             "safe message".to_string(),
@@ -1418,16 +1426,16 @@ mod tests {
     fn test_new_infrastructure_patterns() {
         let redactor = SecretRedactor::new().unwrap();
 
-        // Test Age Secret Key
-        // Length must be exactly 58 chars after prefix
-        let age_key = "AGE-SECRET-KEY-1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54khab";
+        // Test Age Secret Key (runtime-generated to avoid scanner flags)
+        // Length must be exactly 58 lowercase alphanumeric chars after prefix
+        let age_key = format!("AGE-SECRET-KEY-1{}", "a".repeat(58));
         let content1 = format!("age_secret = {}", age_key);
         let matches1 = redactor.scan_for_secrets(&content1, "test.txt").unwrap();
         assert_eq!(matches1.len(), 1);
         assert_eq!(matches1[0].pattern_id, "age_secret_key");
 
-        // Test Vault Service Token
-        let vault_token = "hvs.CAESIKP1234567890abcdef1234567890abcdef12345";
+        // Test Vault Service Token (runtime-generated to avoid scanner flags)
+        let vault_token = format!("hvs.{}", "a".repeat(40));
         let content2 = format!("vault_token = {}", vault_token);
         let matches2 = redactor.scan_for_secrets(&content2, "test.txt").unwrap();
         assert_eq!(matches2.len(), 1);

--- a/docs/DOCTOR.md
+++ b/docs/DOCTOR.md
@@ -234,8 +234,13 @@ xchecker doctor --strict-exit
 
 ## Exit Codes
 
-- **0:** All checks passed (or only warnings in normal mode)
-- **1:** One or more checks failed (or warnings in strict mode)
+| Code | Meaning | JSON Output |
+|------|---------|-------------|
+| **0** | All checks passed (or only warnings in normal mode) | Valid JSON emitted |
+| **1** | One or more checks failed (or warnings in strict mode) | Valid JSON emitted |
+| **2** | Invalid arguments or configuration | No JSON guarantee |
+
+**Note for CI/scripts:** When using `--json`, exit code 1 still produces valid JSON output that can be parsed and processed. The non-zero exit indicates health status, not command failure. If using `set -o pipefail` in shell pipelines, be aware that `doctor --json | jq ...` will fail the pipeline even when the JSON is valid.
 
 ## JSON Output Schema
 

--- a/plans/killer-feature-opportunities.md
+++ b/plans/killer-feature-opportunities.md
@@ -1,0 +1,465 @@
+# xchecker Killer Feature Opportunities
+
+**Analysis Date**: 2026-01-29  
+**Current Version**: 1.1.0  
+**Purpose**: Identify high-impact features that could differentiate xchecker in the market
+
+---
+
+## Executive Summary
+
+xchecker is a mature Rust CLI tool for orchestrating spec generation workflows with LLMs. It has a solid foundation with multi-provider support, controlled execution, secret redaction, and a robust receipt system. However, several killer feature opportunities exist that could significantly enhance its value proposition and market differentiation.
+
+This document identifies 15 killer feature opportunities across 5 categories, assessed by complexity and potential impact.
+
+---
+
+## Category 1: User Experience & Workflow
+
+### 1. Interactive Phase Refinement
+
+**Description**: Enable users to interactively refine LLM outputs during phase execution instead of waiting for complete phase completion.
+
+**Current Limitation**: Users must run phases sequentially and accept/reject entire outputs. No ability to provide mid-execution feedback.
+
+**Proposed Solution**:
+- Add `--interactive` flag to phase commands
+- Display LLM output in real-time with pause points
+- Allow users to provide feedback, request revisions, or continue
+- Support iterative refinement until user is satisfied
+
+**Complexity**: Medium  
+**Impact**: High  
+**Strategic Value**: Differentiates from batch-mode competitors, improves output quality
+
+**Implementation Notes**:
+- Requires streaming LLM response support
+- Need to integrate with existing [`LlmBackend`](crates/xchecker-llm/src/types.rs:251) trait
+- Could leverage existing hooks system for extension points
+
+---
+
+### 2. Visual Diff Viewer
+
+**Description**: Rich visual diff interface for reviewing fixup changes before application.
+
+**Current Limitation**: Fixup preview is text-based with limited formatting. Diff visualization is basic.
+
+**Proposed Solution**:
+- Add `--visual-diff` flag to resume command
+- Render side-by-side or unified diffs with syntax highlighting
+- Support hunk-by-hunk navigation and selective application
+- Integrate with existing [`FixupPreview`](crates/xchecker-fixup-model/src/lib.rs:104) type
+
+**Complexity**: Medium  
+**Impact**: Medium  
+**Strategic Value**: Improves confidence in applying automated changes
+
+**Implementation Notes**:
+- Could use libraries like `diffy` or `similar` for enhanced diff rendering
+- Syntax highlighting via `syntect` or `bat`
+- Extend TUI or create dedicated visual mode
+
+---
+
+### 3. Web Dashboard
+
+**Description**: Browser-based interface for managing specs, viewing status, and monitoring execution.
+
+**Current Limitation**: TUI is read-only and terminal-bound. No remote access or rich visualization.
+
+**Proposed Solution**:
+- Add `xchecker server` command to start web interface
+- Provide REST API for spec management and status queries
+- Real-time WebSocket updates for phase execution
+- Rich visualizations for spec progression, costs, and metrics
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Enables team collaboration, remote monitoring, and better UX
+
+**Implementation Notes**:
+- Could use Actix-web or Axum for HTTP server
+- Leverage existing JSON contracts ([`schemas/`](schemas/)) for API
+- WebSocket support for real-time updates
+- Authentication for multi-user scenarios
+
+---
+
+### 4. Spec Versioning & Rollback
+
+**Description**: Ability to version specs, compare versions, and roll back to previous states.
+
+**Current Limitation**: Receipts provide audit trail but no easy way to manage spec versions or revert changes.
+
+**Proposed Solution**:
+- Add `xchecker spec version` command to create named versions
+- Add `xchecker spec compare` command to diff versions
+- Add `xchecker spec rollback` command to restore previous version
+- Store version metadata alongside artifacts
+
+**Complexity**: Medium  
+**Impact**: High  
+**Strategic Value**: Critical for experimentation and A/B testing of spec approaches
+
+**Implementation Notes**:
+- Extend existing [`receipt`](crates/xchecker-receipt/) system with version tags
+- Could use Git for underlying storage (leverage existing `.git` detection)
+- Integrate with [`workspace.yaml`](examples/fullstack-nextjs/workspace.yaml:1) for version tracking
+
+---
+
+## Category 2: Integration & Automation
+
+### 5. Automated PR Generation
+
+**Description**: Automatically generate pull requests after completing the Fixup phase.
+
+**Current Limitation**: Users must manually create PRs after applying fixup changes.
+
+**Proposed Solution**:
+- Add `--auto-pr` flag to resume command
+- Create branch, commit changes, and open PR via Git/GitHub API
+- Include spec artifacts as PR description or attachments
+- Support custom PR templates
+
+**Complexity**: Medium  
+**Impact**: High  
+**Strategic Value**: Streamlines workflow from spec to code review
+
+**Implementation Notes**:
+- Leverage existing [`fixup`](crates/xchecker-fixup-model/src/lib.rs:1) system for change tracking
+- Use `git2` crate for Git operations
+- GitHub API via `octocrab` or `reqwest`
+- Could be implemented as a post-phase hook
+
+---
+
+### 6. Test Integration & Validation
+
+**Description**: Integrate with test frameworks to validate generated code/tasks automatically.
+
+**Current Limitation**: No automated validation of generated code or implementation tasks.
+
+**Proposed Solution**:
+- Add test execution hooks to phases
+- Define test expectations in spec metadata
+- Run tests after Fixup phase and report results
+- Fail gate if tests don't pass
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Ensures quality of generated code, reduces manual testing
+
+**Implementation Notes**:
+- Extend [`hooks`](crates/xchecker-hooks/src/lib.rs:1) system (already implemented but not wired)
+- Could use existing [`gate`](crates/xchecker-gate/src/lib.rs:1) system for test policies
+- Support multiple test frameworks (cargo test, pytest, jest, etc.)
+
+---
+
+### 7. CI/CD Pipeline Generation
+
+**Description**: Generate CI/CD configuration files based on project type and requirements.
+
+**Current Limitation**: Users must manually create CI/CD pipelines.
+
+**Proposed Solution**:
+- Add `xchecker ci generate` command
+- Generate GitHub Actions, GitLab CI, or Azure Pipelines config
+- Include spec validation, testing, and deployment steps
+- Support custom pipeline templates
+
+**Complexity**: Medium  
+**Impact**: Medium  
+**Strategic Value**: Reduces setup time, ensures best practices
+
+**Implementation Notes**:
+- Could extend existing [`templates`](crates/xchecker-templates/src/lib.rs:1) system
+- Add CI-specific templates (GitHub Actions, GitLab CI, etc.)
+- Integrate with existing [`gate`](crates/xchecker-gate/src/lib.rs:1) system for validation steps
+
+---
+
+## Category 3: Intelligence & Optimization
+
+### 8. Multi-Model Orchestration
+
+**Description**: Use different LLM models for different phases based on task requirements.
+
+**Current Limitation**: Single provider/model per run. No intelligent model selection.
+
+**Proposed Solution**:
+- Add per-phase model configuration
+- Implement model selection heuristics (e.g., use fast models for requirements, smart models for design)
+- Support model fallback chains within a phase
+- Track cost/performance per model
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Optimizes cost and quality, leverages model strengths
+
+**Implementation Notes**:
+- Extend [`LlmBackend`](crates/xchecker-llm/src/types.rs:251) trait for dynamic provider switching
+- Add model selection logic to [`orchestrator`](crates/xchecker-engine/src/orchestrator/)
+- Could use existing [`fallback`](crates/xchecker-llm/src/lib.rs:110) mechanism as foundation
+
+---
+
+### 9. Cost Optimization Engine
+
+**Description**: Intelligent cost management with caching, compression, and smart model selection.
+
+**Current Limitation**: Basic budget control for OpenRouter only. No intelligent optimization.
+
+**Proposed Solution**:
+- Implement response caching for repeated prompts
+- Add context compression for large packets
+- Smart model selection based on task complexity
+- Cost prediction and alerts
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Reduces LLM costs significantly, improves performance
+
+**Implementation Notes**:
+- Extend [`BudgetedBackend`](crates/xchecker-llm/src/lib.rs:32) with caching layer
+- Could use Redis or SQLite for cache storage
+- Integrate with [`packet`](crates/xchecker-packet/src/lib.rs:1) builder for compression
+
+---
+
+### 10. Cross-Project Learning
+
+**Description**: Learn from past specs to improve future spec generation quality.
+
+**Current Limitation**: Each spec is independent. No knowledge transfer between projects.
+
+**Proposed Solution**:
+- Build a knowledge base from successful specs
+- Extract patterns, best practices, and common solutions
+- Use retrieved examples as few-shot prompts
+- Continuous learning from user feedback
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Improves output quality over time, creates competitive moat
+
+**Implementation Notes**:
+- Requires vector database for semantic search (e.g., Qdrant, Weaviate)
+- Could use existing [`receipt`](crates/xchecker-receipt/) metadata for learning
+- Need embedding generation for artifact indexing
+
+---
+
+## Category 4: Collaboration & Sharing
+
+### 11. Spec Marketplace
+
+**Description**: Community-driven marketplace for sharing and discovering spec templates.
+
+**Current Limitation**: Only 4 built-in templates. No way to share or discover community templates.
+
+**Proposed Solution**:
+- Add `xchecker template search` command to query marketplace
+- Add `xchecker template install` to download community templates
+- Support template ratings, reviews, and versioning
+- Allow users to publish their own templates
+
+**Complexity**: High  
+**Impact**: Medium  
+**Strategic Value**: Builds ecosystem, reduces time-to-value
+
+**Implementation Notes**:
+- Need backend service for marketplace (could use GitHub as backend)
+- Extend existing [`templates`](crates/xchecker-templates/src/lib.rs:1) system
+- Could leverage GitHub API for template discovery
+
+---
+
+### 12. Team Collaboration
+
+**Description**: Multi-user support for collaborative spec development.
+
+**Current Limitation**: Single-user workflow. No sharing or real-time collaboration.
+
+**Proposed Solution**:
+- Add spec sharing via links or invitations
+- Real-time collaborative editing
+- Comment and review system
+- Permission management (read, write, admin)
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Enables team use cases, expands market
+
+**Implementation Notes**:
+- Requires backend service for synchronization
+- Could use CRDTs for conflict-free merging
+- Authentication and authorization system required
+- Could integrate with existing [`workspace`](crates/xchecker-workspace/) system
+
+---
+
+### 13. Spec Dependency Management
+
+**Description**: Express and manage dependencies between specs in complex projects.
+
+**Current Limitation**: Specs are independent. No way to model relationships or dependencies.
+
+**Proposed Solution**:
+- Add dependency declarations to [`workspace.yaml`](examples/fullstack-nextjs/workspace.yaml:1)
+- Topological sorting for execution order
+- Dependency-aware status reporting
+- Impact analysis for spec changes
+
+**Complexity**: Medium  
+**Impact**: Medium  
+**Strategic Value**: Enables complex project management
+
+**Implementation Notes**:
+- Extend [`workspace`](crates/xchecker-workspace/) schema with dependencies
+- Implement topological sort algorithm
+- Update [`gate`](crates/xchecker-gate/src/lib.rs:1) system for dependency validation
+
+---
+
+## Category 5: Analytics & Insights
+
+### 14. Analytics Dashboard
+
+**Description**: Comprehensive analytics on spec development patterns, phase completion rates, and LLM performance.
+
+**Current Limitation**: Receipts contain metadata but no aggregation or visualization.
+
+**Proposed Solution**:
+- Add `xchecker analytics` command
+- Track metrics: phase duration, token usage, model performance, success rates
+- Visualize trends and patterns
+- Export reports (CSV, JSON, PDF)
+
+**Complexity**: Medium  
+**Impact**: Medium  
+**Strategic Value**: Helps teams optimize workflows, provides business insights
+
+**Implementation Notes**:
+- Aggregate data from [`receipt`](crates/xchecker-receipt/) system
+- Could use existing [`benchmark`](crates/xchecker-benchmark/) infrastructure
+- Extend TUI or create web dashboard for visualization
+
+---
+
+### 15. Spec Generation from Existing Code
+
+**Description**: Reverse-engineer specs from existing codebases to bootstrap new projects.
+
+**Current Limitation**: Users must write problem statements manually. No code-to-spec conversion.
+
+**Proposed Solution**:
+- Add `xchecker spec bootstrap` command
+- Analyze existing code structure and patterns
+- Generate initial requirements and design documents
+- Identify gaps and improvement opportunities
+
+**Complexity**: High  
+**Impact**: High  
+**Strategic Value**: Reduces onboarding time, enables legacy modernization
+
+**Implementation Notes**:
+- Requires code analysis capabilities (AST parsing, pattern recognition)
+- Could use tree-sitter for multi-language support
+- Integrate with existing [`packet`](crates/xchecker-packet/src/lib.rs:1) builder for context gathering
+
+---
+
+## Priority Matrix
+
+| Feature | Complexity | Impact | Priority | Quick Win |
+|----------|-------------|---------|-----------|------------|
+| Interactive Phase Refinement | Medium | High | P0 | No |
+| Visual Diff Viewer | Medium | Medium | P1 | Yes |
+| Web Dashboard | High | High | P1 | No |
+| Spec Versioning & Rollback | Medium | High | P0 | No |
+| Automated PR Generation | Medium | High | P0 | Yes |
+| Test Integration | High | High | P1 | No |
+| CI/CD Pipeline Generation | Medium | Medium | P2 | Yes |
+| Multi-Model Orchestration | High | High | P1 | No |
+| Cost Optimization Engine | High | High | P1 | No |
+| Cross-Project Learning | High | High | P2 | No |
+| Spec Marketplace | High | Medium | P2 | No |
+| Team Collaboration | High | High | P2 | No |
+| Spec Dependency Management | Medium | Medium | P2 | Yes |
+| Analytics Dashboard | Medium | Medium | P2 | Yes |
+| Spec Generation from Code | High | High | P2 | No |
+
+**Priority Definitions**:
+- **P0**: Critical for core value proposition, should be implemented in next major release
+- **P1**: High-value features that differentiate from competitors
+- **P2**: Nice-to-have features that enhance ecosystem
+
+**Quick Wins**: Features with Medium complexity that can be implemented relatively quickly
+
+---
+
+## Recommended Implementation Roadmap
+
+### Phase 1: Quick Wins (1-2 months)
+1. **Visual Diff Viewer** - Enhances fixup confidence
+2. **Automated PR Generation** - Streamlines workflow
+3. **Spec Dependency Management** - Enables complex projects
+4. **Analytics Dashboard** - Provides immediate value
+
+### Phase 2: Core Differentiators (3-4 months)
+1. **Interactive Phase Refinement** - Major UX improvement
+2. **Spec Versioning & Rollback** - Critical for experimentation
+3. **Multi-Model Orchestration** - Cost/quality optimization
+4. **Test Integration** - Quality assurance
+
+### Phase 3: Ecosystem Builders (6+ months)
+1. **Web Dashboard** - Team collaboration foundation
+2. **Cost Optimization Engine** - Significant cost savings
+3. **Cross-Project Learning** - Competitive moat
+4. **Spec Marketplace** - Community growth
+5. **Team Collaboration** - Enterprise features
+6. **Spec Generation from Code** - Onboarding accelerator
+
+---
+
+## Technical Considerations
+
+### Architecture Implications
+
+1. **Modularization**: The planned v2.0 modularization (19 crates) provides good foundation for these features
+2. **Hooks System**: The existing but unwired [`hooks`](crates/xchecker-hooks/src/lib.rs:1) system should be integrated first
+3. **JSON Contracts**: Existing [`schemas/`](schemas/) provide stable API for web dashboard and integrations
+4. **TUI Foundation**: [`xchecker-tui`](crates/xchecker-tui/src/lib.rs:1) can be extended for visual diff and analytics
+
+### Integration Points
+
+1. **LLM Providers**: New features should work with all existing providers ([`claude-cli`](crates/xchecker-llm/src/claude_cli.rs:1), [`gemini-cli`](crates/xchecker-llm/src/gemini_cli.rs:1), [`openrouter`](crates/xchecker-llm/src/openrouter_backend.rs:1), [`anthropic`](crates/xchecker-llm/src/anthropic_backend.rs:1))
+2. **Fixup System**: All code modification features should use [`fixup-model`](crates/xchecker-fixup-model/src/lib.rs:1)
+3. **Receipt System**: Audit trails should extend existing [`receipt`](crates/xchecker-receipt/) system
+4. **Gate System**: Policy enforcement should leverage [`gate`](crates/xchecker-gate/src/lib.rs:1)
+
+### Dependencies
+
+Some features require external dependencies:
+- Web Dashboard: HTTP server, WebSocket library
+- Cross-Project Learning: Vector database, embedding model
+- Team Collaboration: Backend service, authentication system
+- Spec Marketplace: Backend service or GitHub integration
+
+---
+
+## Conclusion
+
+xchecker has a strong foundation with significant room for growth. The 15 killer features identified here span user experience, integration, intelligence, collaboration, and analytics. 
+
+**Top 5 Recommendations for Immediate Action**:
+1. **Interactive Phase Refinement** - Highest impact, leverages existing architecture
+2. **Spec Versioning & Rollback** - Critical for experimentation
+3. **Automated PR Generation** - Streamlines end-to-end workflow
+4. **Multi-Model Orchestration** - Optimizes cost and quality
+5. **Visual Diff Viewer** - Quick win that improves confidence
+
+These features would significantly enhance xchecker's value proposition and differentiate it from competitors in the AI-assisted development space.

--- a/tests/doc_validation/code_examples_tests.rs
+++ b/tests/doc_validation/code_examples_tests.rs
@@ -1023,6 +1023,41 @@ fn load_fallback_json(filter: &str) -> Value {
     sample.unwrap_or_else(|| json!({ "schema_version": "1", "ok": true }))
 }
 
+/// Extract the subcommand from an xchecker command line.
+///
+/// Scans for a known subcommand token rather than just "first non-flag token",
+/// which avoids false positives when flag values (e.g., `--output-dir /tmp`)
+/// appear before the subcommand.
+///
+/// Returns the subcommand if found, or None if not an xchecker command or
+/// no known subcommand is present.
+fn xchecker_subcommand(cmd: &str) -> Option<&str> {
+    // Known xchecker subcommands (from src/cli.rs Commands enum)
+    const SUBCMDS: &[&str] = &[
+        "spec",
+        "status",
+        "resume",
+        "clean",
+        "benchmark",
+        "test",
+        "doctor",
+        "init",
+        "project",
+        "gate",
+        "template",
+    ];
+
+    let mut tokens = cmd.split_whitespace();
+
+    // First token must be xchecker
+    if tokens.next()? != "xchecker" {
+        return None;
+    }
+
+    // Find first token that matches a known subcommand
+    tokens.find(|tok| SUBCMDS.contains(tok))
+}
+
 fn resolve_jq_input(
     segments: &[String],
     jq_index: usize,
@@ -1051,13 +1086,28 @@ fn resolve_jq_input(
 
     if input_segment.starts_with("xchecker") {
         let result = runner.run_command(input_segment)?;
-        if result.exit_code != 0 {
+
+        // Allow exit code 1 for `xchecker doctor --json` since it means
+        // "some checks failed", not "command error". The doctor command
+        // still produces valid JSON that we can process.
+        //
+        // We only relax for:
+        // - subcommand == "doctor" (detected structurally, not via substring)
+        // - --json flag present (so we expect JSON output)
+        // - exit code == 1 specifically (not 2 for bad args, 70 for provider failure, etc.)
+        let subcmd = xchecker_subcommand(input_segment);
+        let is_doctor_json = subcmd == Some("doctor") && input_segment.contains("--json");
+
+        // Fail on non-zero exit, unless it's doctor --json with exit code 1
+        // (exit code 1 means "checks failed" but JSON is still valid)
+        if result.exit_code != 0 && !(is_doctor_json && result.exit_code == 1) {
             anyhow::bail!(
                 "xchecker command failed (exit {}): {}",
                 result.exit_code,
                 input_segment
             );
         }
+
         let stdout = result.stdout.trim();
         return serde_json::from_str(stdout)
             .with_context(|| format!("Failed to parse JSON from: {input_segment}"));
@@ -1164,4 +1214,82 @@ fn test_jq_examples_from_docs() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod subcommand_tests {
+    use super::xchecker_subcommand;
+
+    #[test]
+    fn test_xchecker_subcommand_basic() {
+        assert_eq!(xchecker_subcommand("xchecker doctor"), Some("doctor"));
+        assert_eq!(xchecker_subcommand("xchecker status"), Some("status"));
+        assert_eq!(xchecker_subcommand("xchecker spec"), Some("spec"));
+        assert_eq!(xchecker_subcommand("xchecker resume"), Some("resume"));
+        assert_eq!(xchecker_subcommand("xchecker gate"), Some("gate"));
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_with_flags_before() {
+        // Flags before subcommand
+        assert_eq!(xchecker_subcommand("xchecker --json doctor"), Some("doctor"));
+        assert_eq!(xchecker_subcommand("xchecker -v doctor"), Some("doctor"));
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_with_flags_after() {
+        // Flags after subcommand - still returns the subcommand
+        assert_eq!(
+            xchecker_subcommand("xchecker doctor --json"),
+            Some("doctor")
+        );
+        assert_eq!(xchecker_subcommand("xchecker status -v"), Some("status"));
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_no_match() {
+        // Not xchecker command
+        assert_eq!(xchecker_subcommand("cargo build"), None);
+        assert_eq!(xchecker_subcommand("echo doctor"), None);
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_only_flags() {
+        // No subcommand, only flags
+        assert_eq!(xchecker_subcommand("xchecker --help"), None);
+        assert_eq!(xchecker_subcommand("xchecker -V"), None);
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_false_positive_prevention() {
+        // These should NOT match "doctor" via substring
+        assert_eq!(
+            xchecker_subcommand("xchecker status --spec doctor-fix"),
+            Some("status")
+        );
+        // A file path containing "doctor" should not be detected as a subcommand
+        // (since "run" is not in SUBCMDS, this returns None, which is correct)
+        assert_eq!(
+            xchecker_subcommand("xchecker --verbose /path/to/doctor/spec"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_xchecker_subcommand_with_flag_value_paths() {
+        // Non-subcommand tokens (paths, values) should be ignored when scanning
+        // for the first known subcommand. This works because paths like "/some/path"
+        // are not in the SUBCMDS list.
+        //
+        // Note: This heuristic can still be fooled if a flag value is literally
+        // a subcommand name (e.g., `--config doctor`), but that's rare in practice.
+        assert_eq!(
+            xchecker_subcommand("xchecker --output-dir /some/path doctor --json"),
+            Some("doctor")
+        );
+        assert_eq!(
+            xchecker_subcommand("xchecker --config /tmp/config.toml status my-spec"),
+            Some("status")
+        );
+    }
 }

--- a/tests/test_unix_process_termination.rs
+++ b/tests/test_unix_process_termination.rs
@@ -27,6 +27,9 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 // ============================================================================
 
 /// Check if a process is still running
+///
+/// Note: This uses `kill(pid, 0)` which can succeed for zombie processes.
+/// For reliable termination checks, prefer `wait_for_exit()` which reaps the child.
 fn is_process_running(pid: u32) -> bool {
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
@@ -34,6 +37,24 @@ fn is_process_running(pid: u32) -> bool {
     let pid = Pid::from_raw(pid as i32);
     // Signal 0 (None) doesn't send a signal but checks if the process exists
     kill(pid, None).is_ok()
+}
+
+/// Wait for a child process to exit with a timeout.
+///
+/// This properly reaps the child process (avoiding zombie issues) by awaiting
+/// `child.wait()` with a timeout. The wait() call is the actual reap operation.
+///
+/// Returns `true` if the child exited within the timeout, `false` otherwise.
+async fn wait_for_exit(child: &mut tokio::process::Child, timeout: Duration) -> bool {
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(_status)) => true, // Process exited and reaped
+        Ok(Err(e)) => {
+            // wait() failed: treat as failure, not success
+            eprintln!("child.wait() failed: {e}");
+            false
+        }
+        Err(_) => false, // Timed out
+    }
 }
 
 /// Create a test script that spawns child processes
@@ -122,7 +143,6 @@ async fn test_process_group_creation() -> Result<()> {
 
 /// Test that SIGTERM is sent first, followed by SIGKILL after grace period
 #[tokio::test]
-#[ignore = "flaky in CI - timing-dependent signal handling"]
 async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
     use nix::sys::signal::{Signal, killpg};
     use nix::unistd::Pid;
@@ -172,17 +192,11 @@ async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
     // Send SIGKILL (cannot be ignored)
     killpg(pgid, Signal::SIGKILL)?;
 
-    // Wait a short time for termination
-    sleep(Duration::from_millis(500)).await;
-
-    // Process should now be terminated
+    // Wait for the process to exit and be reaped (avoids zombie false positives)
     assert!(
-        !is_process_running(pid),
-        "Process should be terminated after SIGKILL"
+        wait_for_exit(&mut child, Duration::from_secs(3)).await,
+        "Process should exit promptly after SIGKILL"
     );
-
-    // Clean up
-    let _ = child.wait().await;
 
     println!("✓ SIGTERM then SIGKILL sequence verified");
     Ok(())
@@ -190,7 +204,6 @@ async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
 
 /// Test that graceful termination works with SIGTERM
 #[tokio::test]
-#[ignore = "flaky in CI - timing-dependent signal handling"]
 async fn test_graceful_termination_with_sigterm() -> Result<()> {
     use nix::sys::signal::{Signal, killpg};
     use nix::unistd::Pid;
@@ -225,17 +238,11 @@ async fn test_graceful_termination_with_sigterm() -> Result<()> {
     // Send SIGTERM
     killpg(pgid, Signal::SIGTERM)?;
 
-    // Wait for graceful termination
-    sleep(Duration::from_millis(500)).await;
-
-    // Process should be terminated (sleep responds to SIGTERM)
+    // Wait for the process to exit and be reaped (avoids zombie false positives)
     assert!(
-        !is_process_running(pid),
-        "Process should be terminated after SIGTERM"
+        wait_for_exit(&mut child, Duration::from_secs(3)).await,
+        "Process should exit promptly after SIGTERM"
     );
-
-    // Clean up
-    let _ = child.wait().await;
 
     println!("✓ Graceful termination with SIGTERM verified");
     Ok(())
@@ -247,7 +254,6 @@ async fn test_graceful_termination_with_sigterm() -> Result<()> {
 
 /// Test that killpg terminates all processes in the group
 #[tokio::test]
-#[ignore = "flaky in CI - timing-dependent process group handling"]
 async fn test_process_group_termination() -> Result<()> {
     use tempfile::TempDir;
 
@@ -294,17 +300,11 @@ async fn test_process_group_termination() -> Result<()> {
     let pgid = Pid::from_raw(parent_pid as i32);
     killpg(pgid, Signal::SIGKILL)?;
 
-    // Wait for termination
-    sleep(Duration::from_millis(500)).await;
-
-    // Verify parent is terminated
+    // Wait for the process to exit and be reaped (avoids zombie false positives)
     assert!(
-        !is_process_running(parent_pid),
-        "Parent process should be terminated"
+        wait_for_exit(&mut child, Duration::from_secs(3)).await,
+        "Parent process should exit promptly after SIGKILL"
     );
-
-    // Clean up
-    let _ = child.wait().await;
 
     println!("✓ Process group termination verified");
     Ok(())
@@ -365,7 +365,6 @@ async fn test_runner_timeout_terminates_process_group() -> Result<()> {
 
 /// Test that timeout with grace period works correctly
 #[tokio::test]
-#[ignore = "flaky in CI - timing-dependent grace period handling"]
 async fn test_timeout_grace_period() -> Result<()> {
     use nix::sys::signal::{Signal, killpg};
     use nix::unistd::Pid;
@@ -413,17 +412,11 @@ async fn test_timeout_grace_period() -> Result<()> {
     // 3. Send SIGKILL
     let _ = killpg(pgid, Signal::SIGKILL);
 
-    // Wait for termination
-    sleep(Duration::from_millis(500)).await;
-
-    // Process should be terminated
+    // Wait for the process to exit and be reaped (avoids zombie false positives)
     assert!(
-        !is_process_running(pid),
-        "Process should be terminated after SIGKILL"
+        wait_for_exit(&mut child, Duration::from_secs(3)).await,
+        "Process should exit promptly after SIGKILL"
     );
-
-    // Clean up
-    let _ = child.wait().await;
 
     println!("✓ Timeout grace period verified (5 seconds)");
     Ok(())


### PR DESCRIPTION
## Summary

* Stabilize unix termination tests by asserting on *reaping* (`child.wait()` with a timeout) rather than PID existence (zombie-safe).
* Make doc jq validation reflect the `doctor --json` contract: exit code **1** is "unhealthy", not "broken", and JSON is still valid.
* Generate token-shaped fixtures at runtime in redaction tests to avoid secret-scanner false positives.
* Clarify `doctor` exit code semantics in docs (including `pipefail` note).
* Add `plans/killer-feature-opportunities.md` (planning doc).

## Details

* `tests/test_unix_process_termination.rs`: `wait_for_exit()` now uses `tokio::time::timeout(timeout, child.wait())`; timeout => false; wait() error => false (strict).
* `tests/doc_validation/code_examples_tests.rs`: `xchecker_subcommand()` scans for a known subcommand set (from CLI `Commands` enum), preventing flag-value mis-detection; jq harness only relaxes non-zero exit for `doctor --json` with exit code **1**.
* `crates/xchecker-redaction/src/lib.rs`: runtime-generated fixtures for GitHub/AWS/etc.
* `docs/DOCTOR.md`: exit codes table + CI/pipeline note.

## Test plan

* `cargo clippy --workspace --all-targets --all-features -- -D warnings`
* `cargo test --workspace --lib`
* `cargo test --features dev-tools --test doc_validation -- --test-threads=1`