### PR TITLE
docs: complete hooks configuration documentation

### DIFF
--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -220,23 +220,204 @@ The minimum timeout is 5 seconds.
 
 ## Hooks
 
-Run scripts before or after any phase. Hooks receive context through environment
-variables (`XCHECKER_SPEC_ID`, `XCHECKER_PHASE`, `XCHECKER_HOOK_TYPE`) and a
-JSON payload on stdin.
+Hooks let you run custom shell scripts before and after any phase in the
+pipeline. Use them for linting, notifications, custom validation, or any
+side-effect you need tied to the spec lifecycle.
+
+### Hook points
+
+There are two hook points per phase:
+
+| Hook point | When it runs | Can abort the phase? |
+|------------|-------------|---------------------|
+| `pre_phase` | Before the LLM is invoked | Yes (when `on_fail = "fail"`) |
+| `post_phase` | After artifacts and receipt are written | No (always treated as warning) |
+
+Both hook points are available for every phase: `requirements`, `design`,
+`tasks`, `review`, `fixup`, and `final`.
+
+### Configuration syntax
+
+Each hook is defined as a TOML table under `[hooks.pre_phase.<phase>]` or
+`[hooks.post_phase.<phase>]`:
 
 ```toml
 [hooks.pre_phase.design]
 command = "./scripts/pre_design.sh"
-on_fail = "warn"          # "warn" (continue) or "fail" (abort phase)
-timeout = 60
+on_fail = "warn"          # "warn" (default) or "fail"
+timeout = 60              # seconds, default 60
 
 [hooks.post_phase.requirements]
 command = "./scripts/post_requirements.sh"
 on_fail = "fail"
+timeout = 30
 ```
 
-Hooks run from the invocation working directory via the platform shell (`sh -c`
-on Unix, `cmd /C` on Windows).
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `command` | Yes | -- | Shell command to execute |
+| `on_fail` | No | `"warn"` | `"warn"`: log and continue; `"fail"`: abort the phase |
+| `timeout` | No | `60` | Maximum execution time in seconds |
+
+You can configure multiple hooks across different phases in the same config
+file. Each phase supports at most one `pre_phase` hook and one `post_phase`
+hook.
+
+### How hooks receive context
+
+Hooks receive context in two ways:
+
+**Environment variables** -- always set for every hook invocation:
+
+| Variable | Description | Example value |
+|----------|-------------|---------------|
+| `XCHECKER_SPEC_ID` | The spec identifier | `my-feature` |
+| `XCHECKER_PHASE` | The phase name | `requirements`, `design`, `tasks`, etc. |
+| `XCHECKER_HOOK_TYPE` | The hook point | `pre_phase` or `post_phase` |
+
+**JSON payload on stdin** -- a JSON object with the same context:
+
+```json
+{"spec_id":"my-feature","phase":"design","hook_type":"pre_phase"}
+```
+
+If the hook does not read stdin, the payload is silently discarded. Hooks are
+free to ignore stdin and rely entirely on environment variables.
+
+### Execution environment
+
+- Hooks run via the platform shell: `sh -c` on Unix, `cmd /C` on Windows.
+- The working directory is the directory where `xchecker` was invoked (not the
+  spec directory), so relative paths like `./scripts/...` work naturally.
+- Stdout and stderr are captured (truncated to 2 KiB each).
+- Hooks are subject to their configured `timeout`. A hook that exceeds its
+  timeout is terminated and treated as a failure.
+
+### Error handling
+
+**Pre-phase hooks:**
+
+- `on_fail = "warn"` (default): A non-zero exit code or timeout is logged as a
+  warning. The warning is recorded in the phase receipt under the `warnings`
+  array. The phase proceeds normally.
+- `on_fail = "fail"`: A non-zero exit code or timeout aborts the phase
+  immediately. A failure receipt is written with a `hook_failure: "pre_phase"`
+  flag for audit purposes. The LLM is never invoked.
+
+**Post-phase hooks:**
+
+Post-phase hooks run after the phase has already succeeded -- artifacts have
+been written and the receipt has been committed. Because of this, post-phase
+hook failures are **always treated as warnings** regardless of the `on_fail`
+setting. This ensures that completed work is never discarded due to a
+notification script failing.
+
+**Hook execution errors** (e.g., command not found, spawn failure) are handled
+the same way as non-zero exit codes: they respect `on_fail` for pre-phase
+hooks and are always warnings for post-phase hooks.
+
+### Receipt integration
+
+Hook outcomes are recorded in the phase receipt:
+
+- Pre-phase hook warnings appear in the receipt's `warnings` array as strings
+  like `hook_failed:pre_phase:design:./scripts/lint.sh:exit_code=1` or
+  `hook_timeout:pre_phase:design:./scripts/lint.sh`.
+- Pre-phase hook failures set the receipt flag `hook_failure: "pre_phase"`.
+- Pre-phase hook execution errors set the receipt flag
+  `hook_error: "pre_phase"`.
+- Post-phase hook warnings are logged but not written to the receipt (the
+  receipt is already committed when the post-phase hook runs).
+
+### Practical examples
+
+**Lint before fixup:**
+
+```toml
+[hooks.pre_phase.fixup]
+command = "cargo clippy --workspace --all-targets -- -D warnings"
+on_fail = "fail"
+timeout = 120
+```
+
+If `clippy` finds warnings, the fixup phase is aborted so you can address lint
+issues before applying LLM-proposed changes.
+
+**Notify after review:**
+
+```toml
+[hooks.post_phase.review]
+command = "curl -s -X POST https://hooks.slack.com/services/T.../B.../xxx -d '{\"text\":\"Review phase completed for spec '\"$XCHECKER_SPEC_ID\"'\"}'"
+on_fail = "warn"
+timeout = 10
+```
+
+Sends a Slack notification when the review phase finishes. The short timeout
+and `on_fail = "warn"` ensure a network hiccup does not block the workflow.
+
+**Custom validation after requirements:**
+
+```toml
+[hooks.post_phase.requirements]
+command = "./scripts/validate_requirements.sh"
+on_fail = "warn"
+timeout = 30
+```
+
+Where `validate_requirements.sh` reads stdin for context:
+
+```bash
+#!/usr/bin/env bash
+# Read the JSON context from stdin
+CONTEXT=$(cat)
+SPEC_ID=$(echo "$CONTEXT" | jq -r .spec_id)
+
+# Check that the requirements artifact exists and has content
+ARTIFACT=".xchecker/specs/${SPEC_ID}/artifacts/00-requirements.md"
+if [ ! -s "$ARTIFACT" ]; then
+  echo "ERROR: requirements artifact is empty or missing" >&2
+  exit 1
+fi
+
+echo "Requirements validation passed for ${SPEC_ID}"
+```
+
+**Gate design on requirements quality:**
+
+```toml
+[hooks.pre_phase.design]
+command = "./scripts/check_requirements_quality.sh"
+on_fail = "fail"
+timeout = 30
+```
+
+This blocks the design phase from starting unless the requirements artifact
+passes your quality checks.
+
+**All phases -- universal logging:**
+
+```toml
+[hooks.pre_phase.requirements]
+command = "echo \"Starting $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+
+[hooks.pre_phase.design]
+command = "echo \"Starting $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+
+[hooks.pre_phase.tasks]
+command = "echo \"Starting $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+
+[hooks.post_phase.requirements]
+command = "echo \"Finished $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+
+[hooks.post_phase.design]
+command = "echo \"Finished $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+
+[hooks.post_phase.tasks]
+command = "echo \"Finished $XCHECKER_PHASE for $XCHECKER_SPEC_ID\" >> /tmp/xchecker.log"
+```
+
+Each phase must be configured individually -- there is no wildcard hook that
+applies to all phases.
 
 ---
 

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -121,15 +121,73 @@ Per-phase overrides. Phase keys: `requirements`, `design`, `tasks`, `review`,
 | `claude_path` | String | `null` | Custom Claude CLI path |
 | `phase_timeout` | Integer | `600` | Phase timeout in seconds (minimum 5) |
 
-### [hooks.pre_phase.<phase>] and [hooks.post_phase.<phase>]
+### [hooks]
 
-Phase keys: `requirements`, `design`, `tasks`, `review`, `fixup`, `final`.
+The `[hooks]` section configures custom shell scripts that run before or after
+phase execution. Hooks are organized into two sub-tables: `pre_phase` (runs
+before the LLM is invoked) and `post_phase` (runs after artifacts and receipt
+are written).
+
+Each sub-table is keyed by phase name. Phase keys: `requirements`, `design`,
+`tasks`, `review`, `fixup`, `final`.
+
+#### [hooks.pre_phase.\<phase\>]
+
+Pre-phase hooks run before the LLM invocation. If `on_fail = "fail"` and the
+hook exits non-zero or times out, the phase is aborted and a failure receipt is
+written with `hook_failure: "pre_phase"`. If `on_fail = "warn"`, the warning is
+recorded in the receipt's `warnings` array and the phase proceeds.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `command` | String | Required | Shell command to execute |
-| `on_fail` | String | `"warn"` | Failure behavior (`warn` or `fail`) |
-| `timeout` | Integer | `60` | Hook timeout in seconds |
+| `command` | String | Required | Shell command to execute (via `sh -c` on Unix, `cmd /C` on Windows) |
+| `on_fail` | String | `"warn"` | Failure behavior: `"warn"` logs and continues; `"fail"` aborts the phase |
+| `timeout` | Integer | `60` | Maximum execution time in seconds; the hook is terminated if exceeded |
+
+#### [hooks.post_phase.\<phase\>]
+
+Post-phase hooks run after the phase succeeds (artifacts written, receipt
+committed). Because the phase is already complete, post-phase hook failures are
+**always treated as warnings** regardless of the `on_fail` setting.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | String | Required | Shell command to execute (via `sh -c` on Unix, `cmd /C` on Windows) |
+| `on_fail` | String | `"warn"` | Failure behavior: effectively always `"warn"` for post-phase hooks |
+| `timeout` | Integer | `60` | Maximum execution time in seconds; the hook is terminated if exceeded |
+
+#### Hook environment variables
+
+All hooks receive these environment variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `XCHECKER_SPEC_ID` | Spec identifier | `my-feature` |
+| `XCHECKER_PHASE` | Phase name | `design` |
+| `XCHECKER_HOOK_TYPE` | Hook point | `pre_phase` or `post_phase` |
+
+Additionally, a JSON payload with the same context is written to the hook's
+stdin: `{"spec_id":"...","phase":"...","hook_type":"..."}`.
+
+#### Hook execution details
+
+- Working directory: the directory where `xchecker` was invoked.
+- Stdout and stderr are captured and truncated to 2048 bytes each.
+- Timeouts terminate the hook process; the result is treated as a failure.
+
+#### Example
+
+```toml
+[hooks.pre_phase.fixup]
+command = "cargo clippy --workspace -- -D warnings"
+on_fail = "fail"
+timeout = 120
+
+[hooks.post_phase.review]
+command = "./scripts/notify_slack.sh"
+on_fail = "warn"
+timeout = 10
+```
 
 ### [security]
 


### PR DESCRIPTION
## Summary

Expands the hooks section in both configuration docs from a brief stub into comprehensive documentation.

- **guides/CONFIGURATION.md**: ~180 lines added covering hook points table, config syntax, context delivery (env vars + JSON stdin), execution environment, error handling (pre vs post semantics), receipt integration, and 5 practical examples (lint before fixup, Slack notifications, requirements validation, design gating, universal logging)
- **reference/CONFIGURATION.md**: Expanded `[hooks]` reference with structured tables for pre/post phase keys, environment variables, and execution details

Key finding documented: post-phase `on_fail = "fail"` is effectively a no-op (always warning) because the receipt is already committed.

## Test plan

- [x] Docs-only change, no code modified
- [ ] Links resolve correctly in rendered markdown