### PR TITLE
fix: add #[serial] to config tests that modify global state

### DIFF
--- a/tests/integration_full_workflows.rs
+++ b/tests/integration_full_workflows.rs
@@ -15,6 +15,7 @@
 //! - R4.2: Resume scenarios and failure recovery
 
 use anyhow::Result;
+use serial_test::serial;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -126,6 +127,7 @@ impl WorkflowTestEnvironment {
 /// Test 1: Complete spec generation flow (Requirements → Design → Tasks)
 /// Validates R1.1 requirements for full workflow execution
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_complete_spec_generation_flow() -> Result<()> {
     let env = WorkflowTestEnvironment::new("complete-flow")?;
@@ -252,6 +254,7 @@ async fn test_complete_spec_generation_flow() -> Result<()> {
 /// Test 2: Resume scenarios and failure recovery
 /// Validates R4.2 requirements for phase resumption and failure handling
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_resume_scenarios_and_failure_recovery() -> Result<()> {
     let env = WorkflowTestEnvironment::new("resume-recovery")?;
@@ -354,6 +357,7 @@ async fn test_resume_scenarios_and_failure_recovery() -> Result<()> {
 /// Test 3: Determinism with identical inputs producing same outputs
 /// Validates R2.2 and R2.5 requirements for deterministic behavior
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_determinism_with_identical_inputs() -> Result<()> {
     // Create two separate environments with identical configurations
@@ -487,6 +491,7 @@ async fn test_determinism_with_identical_inputs() -> Result<()> {
 /// Test 4: Multi-phase workflow with dependency validation
 /// Validates proper phase dependency checking and artifact propagation
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_multi_phase_workflow_with_dependencies() -> Result<()> {
     let env = WorkflowTestEnvironment::new("dependencies")?;
@@ -589,6 +594,7 @@ async fn test_multi_phase_workflow_with_dependencies() -> Result<()> {
 /// Test 5: Artifact content validation and structure verification
 /// Validates that generated artifacts have proper structure and content
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_artifact_content_validation() -> Result<()> {
     let env = WorkflowTestEnvironment::new("content-validation")?;
@@ -684,6 +690,7 @@ async fn test_artifact_content_validation() -> Result<()> {
 /// Test 6: Error propagation and recovery across phases
 /// Validates proper error handling in multi-phase scenarios
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_error_propagation_and_recovery() -> Result<()> {
     if !test_support::should_run_e2e() {

--- a/tests/m3_gate_validation.rs
+++ b/tests/m3_gate_validation.rs
@@ -16,6 +16,7 @@
 //! - R4.2: Resume functionality from intermediate phases
 
 use anyhow::Result;
+use serial_test::serial;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -201,6 +202,7 @@ spec_id: "test-spec-123"
 /// Test 2: Run Requirements → Design → Tasks flow end-to-end
 /// Validates R1.1 requirements for complete multi-phase workflow
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_complete_multi_phase_flow() -> Result<()> {
     let env = M3TestEnvironment::new("multi-phase-flow")?;
@@ -410,6 +412,7 @@ async fn test_complete_multi_phase_flow() -> Result<()> {
 /// Test 3: Verify resume functionality from intermediate phases
 /// Validates R4.2 requirements for resume capability
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_resume_functionality_from_intermediate_phases() -> Result<()> {
     let env = M3TestEnvironment::new("resume-functionality")?;
@@ -540,6 +543,7 @@ async fn test_resume_functionality_from_intermediate_phases() -> Result<()> {
 /// Test 4: Verify canonicalization of actual generated *.core.yaml files
 /// Tests that real generated YAML files produce consistent hashes
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_generated_core_yaml_canonicalization() -> Result<()> {
     let env = M3TestEnvironment::new("generated-yaml-canon")?;
@@ -621,6 +625,7 @@ async fn test_generated_core_yaml_canonicalization() -> Result<()> {
 /// Test 5: Verify dependency checking prevents invalid resume scenarios
 /// Tests that resume fails appropriately when dependencies are not satisfied
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_resume_dependency_validation() -> Result<()> {
     let env = M3TestEnvironment::new("resume-deps")?;
@@ -702,6 +707,7 @@ async fn test_resume_dependency_validation() -> Result<()> {
 /// Test 6: Verify canonicalization version and backend information
 /// Tests that canonicalization metadata is properly recorded
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_canonicalization_metadata_in_receipts() -> Result<()> {
     let env = M3TestEnvironment::new("canon-metadata")?;
@@ -784,6 +790,7 @@ async fn test_canonicalization_metadata_in_receipts() -> Result<()> {
 /// Comprehensive M3 Gate validation test
 /// Runs all M3 Gate tests in sequence to validate the milestone
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_m3_gate_comprehensive_validation() -> Result<()> {
     println!("🚀 Starting M3 Gate comprehensive validation...");

--- a/tests/m4_gate_validation.rs
+++ b/tests/m4_gate_validation.rs
@@ -17,6 +17,7 @@
 //! - R7.5: Verbose logging provides detailed operation logs
 
 use anyhow::Result;
+use serial_test::serial;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -276,6 +277,7 @@ These changes are essential for a complete specification.
 /// Test 3: Verify status command shows complete phase information
 /// Validates R2.6 requirements for status command functionality
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_status_command_shows_complete_phase_information() -> Result<()> {
     let env = M4TestEnvironment::new("status-info")?;
@@ -417,6 +419,7 @@ async fn test_status_command_shows_complete_phase_information() -> Result<()> {
 /// Test 4: Confirm verbose logging provides useful debugging information
 /// Validates R7.5 requirements for verbose logging functionality
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_verbose_logging_provides_debugging_information() -> Result<()> {
     let env = M4TestEnvironment::new("verbose-logging")?;
@@ -614,6 +617,7 @@ fn test_fixup_validation_with_git_apply_check() -> Result<()> {
 /// Test 6: Verify status command handles empty spec gracefully
 /// Tests status command behavior when spec exists but has no artifacts or receipts
 #[test]
+#[serial]
 fn test_status_command_handles_empty_spec() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let _cwd_guard = test_support::CwdGuard::new(temp_dir.path())?;
@@ -643,6 +647,7 @@ fn test_status_command_handles_empty_spec() -> Result<()> {
 /// Test 7: Verify review phase integration with fixup detection
 /// Tests end-to-end review phase that produces fixup markers
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_review_phase_integration_with_fixup_detection() -> Result<()> {
     let env = M4TestEnvironment::new("review-integration")?;
@@ -759,6 +764,7 @@ These changes will improve the specification completeness.
 /// Comprehensive M4 Gate validation test
 /// Runs all M4 Gate tests in sequence to validate the milestone
 #[tokio::test]
+#[serial]
 #[ignore = "requires_claude_stub"]
 async fn test_m4_gate_comprehensive_validation() -> Result<()> {
     println!("🚀 Starting M4 Gate comprehensive validation...");

--- a/tests/security_path_traversal.rs
+++ b/tests/security_path_traversal.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use serial_test::serial;
 use tempfile::TempDir;
 use xchecker::OrchestratorHandle;
 use xchecker::artifact::{Artifact, ArtifactType};
@@ -42,6 +43,7 @@ impl SecurityTestEnvironment {
 /// Validates that ArtifactManager rejects paths attempting to escape the spec directory
 /// Requirements: FR-TEST-6
 #[test]
+#[serial]
 fn test_artifact_path_traversal_rejection() -> Result<()> {
     let env = SecurityTestEnvironment::new("artifact-traversal")?;
     let manager = env.handle.artifact_manager();
@@ -68,6 +70,7 @@ fn test_artifact_path_traversal_rejection() -> Result<()> {
 /// Validates that FixupParser rejects diffs targeting files outside the repo
 /// Requirements: FR-TEST-6
 #[test]
+#[serial]
 fn test_fixup_path_traversal_rejection() -> Result<()> {
     let env = SecurityTestEnvironment::new("fixup-traversal")?;
 

--- a/tests/test_doctor_llm_checks.rs
+++ b/tests/test_doctor_llm_checks.rs
@@ -15,6 +15,7 @@
 //! These tests ensure the doctor command properly validates the LLM backend
 //! configuration before any actual LLM calls are made.
 
+use serial_test::serial;
 use std::env;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::{NamedTempFile, TempDir};
@@ -90,6 +91,7 @@ fn find_check<'a>(
 // ===== Test Scenario 1: No provider set → should default and pass/warn based on binary availability =====
 
 #[test]
+#[serial]
 fn test_no_provider_set_defaults_to_claude_cli() {
     let _env = TestEnv::new();
 
@@ -139,6 +141,7 @@ fn test_no_provider_set_defaults_to_claude_cli() {
 }
 
 #[test]
+#[serial]
 fn test_no_provider_no_binary_in_path_fails() {
     let _env = TestEnv::new();
 
@@ -191,6 +194,7 @@ fn test_no_provider_no_binary_in_path_fails() {
 // ===== Test Scenario 2: Provider = "claude-cli" with invalid binary path → should fail =====
 
 #[test]
+#[serial]
 fn test_claude_cli_with_invalid_binary_path_fails() {
     let _env = TestEnv::new();
 
@@ -239,6 +243,7 @@ fn test_claude_cli_with_invalid_binary_path_fails() {
 // ===== Test Scenario 3: Provider = "claude-cli" with valid custom binary path → should pass =====
 
 #[test]
+#[serial]
 fn test_claude_cli_with_valid_custom_binary_passes() {
     let _env = TestEnv::new();
 
@@ -286,6 +291,7 @@ fn test_claude_cli_with_valid_custom_binary_passes() {
 // ===== Test Scenario 4: Invalid/unsupported provider → should fail during config validation =====
 
 #[test]
+#[serial]
 fn test_unsupported_provider_fails_config_validation() {
     let _env = TestEnv::new();
 
@@ -316,6 +322,7 @@ fn test_unsupported_provider_fails_config_validation() {
 }
 
 #[test]
+#[serial]
 fn test_unknown_provider_fails_config_validation() {
     let _env = TestEnv::new();
 
@@ -338,6 +345,7 @@ fn test_unknown_provider_fails_config_validation() {
 // ===== Test Scenario 5: Doctor JSON output includes llm_provider check =====
 
 #[test]
+#[serial]
 fn test_doctor_json_output_includes_llm_provider_check() {
     let _env = TestEnv::new();
 
@@ -388,6 +396,7 @@ fn test_doctor_json_output_includes_llm_provider_check() {
 // ===== Test Scenario 6: Doctor strict mode with warnings =====
 
 #[test]
+#[serial]
 fn test_doctor_strict_mode_with_llm_warnings() {
     let _env = TestEnv::new();
 
@@ -441,6 +450,7 @@ fn test_doctor_strict_mode_with_llm_warnings() {
 // ===== Test Scenario 7: Verify check is present in all statuses =====
 
 #[test]
+#[serial]
 fn test_llm_provider_check_always_present() {
     let _env = TestEnv::new();
 
@@ -482,6 +492,7 @@ fn test_llm_provider_check_always_present() {
 // ===== Test Scenario 8: Provider check details are informative =====
 
 #[test]
+#[serial]
 fn test_llm_provider_check_details_are_informative() {
     let _env = TestEnv::new();
 
@@ -521,6 +532,7 @@ fn test_llm_provider_check_details_are_informative() {
 // ===== Test Scenario 9: Multiple doctor runs produce consistent results =====
 
 #[test]
+#[serial]
 fn test_llm_provider_check_consistency() {
     let _env = TestEnv::new();
 
@@ -566,6 +578,7 @@ fn test_llm_provider_check_consistency() {
 // ===== Test Scenario 10: Edge case - relative path for binary =====
 
 #[test]
+#[serial]
 fn test_llm_provider_with_relative_path() {
     let _env = TestEnv::new();
 

--- a/tests/test_fixup_command_integration.rs
+++ b/tests/test_fixup_command_integration.rs
@@ -16,6 +16,7 @@
 //! - Receipt writing with fixup results works
 
 use anyhow::Result;
+use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
 use xchecker::fixup::{FixupMode, FixupParser};
@@ -39,6 +40,7 @@ fn setup_test_environment(test_name: &str) -> Result<(PhaseOrchestrator, TempDir
 
 /// Test that fixup command parsing works in resume
 #[tokio::test]
+#[serial]
 async fn test_fixup_command_parsing() -> Result<()> {
     let (orchestrator, _temp_dir) = setup_test_environment("command-parsing")?;
 

--- a/tests/test_hooks_integration.rs
+++ b/tests/test_hooks_integration.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use anyhow::Result;
+use serial_test::serial;
 use tempfile::TempDir;
 use xchecker::exit_codes;
 use xchecker::hooks::{DEFAULT_HOOK_TIMEOUT_SECS, HookConfig, HooksConfig, OnFail};
@@ -55,6 +56,7 @@ fn unique_spec_id(test_name: &str) -> String {
 }
 
 #[tokio::test]
+#[serial]
 #[allow(clippy::await_holding_lock)] // Lock serializes tests; safe in single-threaded test context
 async fn test_pre_and_post_hooks_execute() -> Result<()> {
     let _guard = hook_env_guard();
@@ -117,6 +119,7 @@ async fn test_pre_and_post_hooks_execute() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 #[allow(clippy::await_holding_lock)] // Lock serializes tests; safe in single-threaded test context
 async fn test_pre_phase_hook_failure_aborts_phase() -> Result<()> {
     let _guard = hook_env_guard();

--- a/tests/test_m4_gate_validation.rs
+++ b/tests/test_m4_gate_validation.rs
@@ -9,6 +9,7 @@
 //! Requirements: R6.8, R6.9, R7.1, R7.2, R7.3
 
 use anyhow::Result;
+use serial_test::serial;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -208,6 +209,7 @@ fn test_error_receipt_exit_code_alignment() {
 
 /// Test that timeout creates partial artifact with correct naming
 #[tokio::test]
+#[serial]
 async fn test_timeout_creates_partial_artifact() -> Result<()> {
     let env = setup_test_environment("timeout-partial");
     let spec_base = env.spec_base;
@@ -598,6 +600,7 @@ mod integration_tests {
 
     /// Integration test for timeout behavior (requires mock or stub)
     #[tokio::test]
+    #[serial]
     #[ignore = "requires_claude_stub"]
     async fn test_timeout_full_integration() -> Result<()> {
         let _env_guard = test_support::EnvVarGuard::set("CLAUDE_STUB_HANG_SECS", "10");

--- a/tests/test_phase_timeout.rs
+++ b/tests/test_phase_timeout.rs
@@ -12,6 +12,7 @@
 //! 4. Exit code is 10 for timeouts
 
 use anyhow::Result;
+use serial_test::serial;
 use std::collections::HashMap;
 use tempfile::TempDir;
 use xchecker::orchestrator::{OrchestratorConfig, PhaseOrchestrator, PhaseTimeout};
@@ -134,6 +135,7 @@ fn test_phase_timeout_from_config() {
 /// Test that timeout creates partial artifact and receipt with warning
 /// This is a smoke test that validates the core timeout behavior
 #[tokio::test]
+#[serial]
 async fn test_timeout_creates_partial_and_receipt() -> Result<()> {
     let _env = setup_test_environment("partial");
 
@@ -235,6 +237,7 @@ mod integration_tests {
     /// This test would require a mock Claude CLI that sleeps longer than the timeout
     /// For now, it's a placeholder for future integration testing
     #[tokio::test]
+    #[serial]
     #[ignore = "requires_claude_stub"]
     async fn test_full_timeout_flow_with_mock() -> Result<()> {
         let _env_guard = test_support::EnvVarGuard::set("CLAUDE_STUB_HANG_SECS", "10");

--- a/tests/test_workflow_receipt_regression.rs
+++ b/tests/test_workflow_receipt_regression.rs
@@ -11,6 +11,7 @@
 //! 4. Packet evidence is preserved
 
 use anyhow::Result;
+use serial_test::serial;
 use tempfile::TempDir;
 use xchecker::orchestrator::{OrchestratorConfig, PhaseOrchestrator};
 
@@ -55,6 +56,7 @@ fn dry_run_config() -> OrchestratorConfig {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_requirements_receipt_has_llm_info() -> Result<()> {
     let env = setup_test("llm-info");
     let orchestrator = env.orchestrator;
@@ -83,6 +85,7 @@ async fn test_requirements_receipt_has_llm_info() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_requirements_receipt_has_pipeline_info() -> Result<()> {
     let env = setup_test("pipeline-info");
     let orchestrator = env.orchestrator;
@@ -109,6 +112,7 @@ async fn test_requirements_receipt_has_pipeline_info() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_receipt_packet_evidence_preserved() -> Result<()> {
     let env = setup_test("packet-evidence");
     let orchestrator = env.orchestrator;
@@ -138,6 +142,7 @@ async fn test_receipt_packet_evidence_preserved() -> Result<()> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_multi_phase_receipts_consistent_metadata() -> Result<()> {
     let env = setup_test("multi-phase");
     let orchestrator = env.orchestrator;
@@ -171,6 +176,7 @@ async fn test_multi_phase_receipts_consistent_metadata() -> Result<()> {
 /// and workflow execution contain the same key metadata fields, ensuring
 /// consistency regardless of execution path.
 #[tokio::test]
+#[serial]
 async fn test_single_phase_vs_workflow_receipt_parity() -> Result<()> {
     // Run Requirements via single-phase path
     let env_single = setup_test("single-phase-parity");


### PR DESCRIPTION
## Summary

Added `#[serial]` to 43 integration tests across 10 test files that modify process-global state (CWD via `CwdGuard` or env vars) but were missing serialization annotations. This prevents parallel test interference that causes flaky failures.

| File | Tests | Global mutation |
|------|-------|-----------------|
| `test_doctor_llm_checks.rs` | 12 | `env::set_var("PATH")` |
| `integration_full_workflows.rs` | 6 | `CwdGuard` |
| `m3_gate_validation.rs` | 6 | `CwdGuard` |
| `m4_gate_validation.rs` | 5 | `CwdGuard` |
| `test_workflow_receipt_regression.rs` | 5 | `CwdGuard` |
| `test_m4_gate_validation.rs` | 2 | `CwdGuard` |
| `test_phase_timeout.rs` | 2 | `CwdGuard` |
| `test_hooks_integration.rs` | 2 | `CwdGuard` |
| `security_path_traversal.rs` | 2 | `CwdGuard` |
| `test_fixup_command_integration.rs` | 1 | `env::set_var("XCHECKER_HOME")` |

Tests that already have proper serialization (module-local mutexes, `with_isolated_home()`, existing `#[serial]`) were left unchanged.

## Test plan

- [x] `cargo test --workspace --lib` passes
- [x] `cargo test --workspace --tests --no-run` compiles
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean