### PR TITLE
fix: improve CI schedule/nightly reliability

### DIFF
--- a/.github/workflows/dependency-management.yml
+++ b/.github/workflows/dependency-management.yml
@@ -33,6 +33,10 @@ on:
           - security-only
           - duplicates-only
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -43,12 +47,13 @@ jobs:
   # ============================================================================
   test-locked:
     name: Test Locked (${{ matrix.os }})
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -100,12 +105,13 @@ jobs:
   # ============================================================================
   test-fresh:
     name: Test Fresh Resolve (${{ matrix.os }})
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -167,8 +173,9 @@ jobs:
   # ============================================================================
   check-duplicates:
     name: Dependency Duplication Check
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -215,8 +222,9 @@ jobs:
   # ============================================================================
   security-scan:
     name: Security Scan
+    timeout-minutes: 20
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -310,8 +318,9 @@ jobs:
   # ============================================================================
   msrv-check:
     name: MSRV Check (Rust 1.89)
+    timeout-minutes: 30
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -355,9 +364,10 @@ jobs:
   # ============================================================================
   monitor-drift:
     name: Dependency Drift Monitor
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -407,8 +417,9 @@ jobs:
   # ============================================================================
   validate-policy:
     name: Validate Hybrid Policy
+    timeout-minutes: 10
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -511,10 +522,11 @@ jobs:
   # ============================================================================
   dependency-summary:
     name: Dependency Management Summary
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [test-locked, test-fresh, check-duplicates, security-scan, msrv-check, validate-policy]
     if: always()
-    
+
     steps:
       - name: Dependency Management Summary
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ on:
           - fast
           - full
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -38,6 +42,7 @@ jobs:
   test-fast:
     name: Test Fast (${{ matrix.os }})
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'fast')
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -73,10 +78,13 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Schedule runs use only ubuntu to reduce runner pressure on free-tier repos.
+        # Push and dispatch runs test all three platforms.
+        os: ${{ github.event_name == 'schedule' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -147,6 +155,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -191,6 +200,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       XCHECKER_E2E: "1"
@@ -243,6 +253,7 @@ jobs:
   # ============================================================================
   example-validation:
     name: Example Validation (${{ matrix.os }})
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -281,6 +292,7 @@ jobs:
   # ============================================================================
   walkthrough-validation:
     name: Walkthrough Validation (${{ matrix.os }})
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Nightly schedule runs in both `test.yml` and `dependency-management.yml` have been failing for weeks. Runners were allocated but never executed steps, and the schedule SHA was stuck at `5d41a1d` even though `main` HEAD is `e45db2a`. Push-triggered `test-full` runs also never appeared in the run history.

Root causes:
- **No concurrency control**: Schedule runs queued nightly with no cancellation of stale predecessors, exhausting free-tier runner slots.
- **No timeouts**: Hung runners occupied slots until GitHub's 6-hour default, blocking subsequent runs.
- **Excessive parallelism on schedule**: 3-OS matrix for `test-full`, `test-locked`, and `test-fresh` on every nightly trigger consumed too many concurrent runners for a free-tier repo.

### Changes

- **Concurrency groups** added to both workflows (`${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`) so new runs on the same ref cancel stale queued/in-progress runs.
- **`timeout-minutes`** added to every job in both workflows (5-30 min depending on expected duration) to prevent hung runners from blocking the queue.
- **Reduced nightly matrix** for `test-full` (test.yml), `test-locked`, and `test-fresh` (dependency-management.yml): schedule-triggered runs now use only `ubuntu-latest`. Push, PR, and dispatch events still test all three platforms.

### Files changed

- `.github/workflows/test.yml`
- `.github/workflows/dependency-management.yml`

## Test plan

- [ ] Verify the PR's own CI run starts and completes (not hung)
- [ ] After merge, monitor the next nightly schedule run at ~02:00 UTC to confirm it allocates runners AND executes steps
- [ ] Trigger a manual `workflow_dispatch` for both workflows to confirm full 3-OS matrix still runs on dispatch
- [ ] Confirm push-to-main triggers `test-full` with the full 3-OS matrix