### PR TITLE
fix: optimize CI schedule triggers and add runner safeguards

### DIFF
--- a/.github/workflows/dependency-management.yml
+++ b/.github/workflows/dependency-management.yml
@@ -10,6 +10,8 @@
 # - Security scanning for critical dependencies
 # - MSRV enforcement with Rust 1.89
 # - Dependency drift detection
+#
+# Schedule runs are limited to ubuntu-latest to conserve runner minutes.
 
 name: Dependency Management
 
@@ -19,8 +21,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run nightly at 3:00 AM UTC for dependency monitoring
-    - cron: '0 3 * * *'
+    # Run weekly on Monday at 3:00 AM UTC (was daily; reduced to save minutes)
+    - cron: '0 3 * * 1'
   workflow_dispatch:
     inputs:
       scan_mode:
@@ -32,6 +34,18 @@ on:
           - full
           - security-only
           - duplicates-only
+      platform:
+        description: 'Platform(s) to run on'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - ubuntu-only
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,12 +57,14 @@ jobs:
   # ============================================================================
   test-locked:
     name: Test Locked (${{ matrix.os }})
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Schedule runs use ubuntu-only to save runner minutes.
+        os: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.platform == 'ubuntu-only')) && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -100,12 +116,14 @@ jobs:
   # ============================================================================
   test-fresh:
     name: Test Fresh Resolve (${{ matrix.os }})
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Schedule runs use ubuntu-only to save runner minutes.
+        os: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.platform == 'ubuntu-only')) && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -167,8 +185,9 @@ jobs:
   # ============================================================================
   check-duplicates:
     name: Dependency Duplication Check
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -215,8 +234,9 @@ jobs:
   # ============================================================================
   security-scan:
     name: Security Scan
+    timeout-minutes: 20
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -310,8 +330,9 @@ jobs:
   # ============================================================================
   msrv-check:
     name: MSRV Check (Rust 1.89)
+    timeout-minutes: 20
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -355,9 +376,10 @@ jobs:
   # ============================================================================
   monitor-drift:
     name: Dependency Drift Monitor
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -407,8 +429,9 @@ jobs:
   # ============================================================================
   validate-policy:
     name: Validate Hybrid Policy
+    timeout-minutes: 10
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -511,10 +534,11 @@ jobs:
   # ============================================================================
   dependency-summary:
     name: Dependency Management Summary
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [test-locked, test-fresh, check-duplicates, security-scan, msrv-check, validate-policy]
     if: always()
-    
+
     steps:
       - name: Dependency Management Summary
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,10 @@
 #
 # This workflow implements the test-fast and test-full lanes:
 # - test-fast: Runs on every PR for quick feedback (~30s)
-# - test-full: Runs nightly and on main branch for comprehensive coverage
+# - test-full: Runs on push to main for comprehensive coverage
+#
+# Schedule runs are limited to ubuntu-latest to conserve runner minutes.
+# Use workflow_dispatch with platform=all to run on all 3 platforms manually.
 #
 # See docs/TESTING.md for test lane documentation.
 
@@ -14,8 +17,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run nightly at 2:00 AM UTC
-    - cron: '0 2 * * *'
+    # Run weekly on Monday at 2:00 AM UTC (was daily; reduced to save minutes)
+    - cron: '0 2 * * 1'
   workflow_dispatch:
     inputs:
       test_lane:
@@ -26,6 +29,18 @@ on:
         options:
           - fast
           - full
+      platform:
+        description: 'Platform(s) to run on'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - ubuntu-only
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,6 +53,7 @@ jobs:
   test-fast:
     name: Test Fast (${{ matrix.os }})
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'fast')
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -73,10 +89,13 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Schedule runs use ubuntu-only to save runner minutes.
+        # Push runs and manual 'all' dispatches use all 3 platforms.
+        os: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.platform == 'ubuntu-only')) && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -100,11 +119,43 @@ jobs:
       - name: Run test-full (all tests) - Locked
         run: cargo test --all-features --locked
         env:
-          # Increase property test cases for nightly runs
           PROPTEST_CASES: 128
 
-      - name: Run test-full (all tests) - Fresh Resolve (Linux)
-        if: runner.os == 'Linux'
+      - name: Run doc tests
+        run: cargo test --doc
+
+  # ============================================================================
+  # FRESH RESOLVE: Catches dependency drift (weekly schedule only)
+  # ============================================================================
+  # Separated from test-full so push builds are not doubled.
+  # Runs as part of the weekly schedule and on manual 'full' dispatches.
+  fresh-resolve:
+    name: Fresh Resolve (ubuntu)
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-cargo-fresh-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ubuntu-cargo-fresh-
+            ubuntu-cargo-
+
+      - name: Fresh resolve and test
         shell: bash
         run: |
           set -euo pipefail
@@ -123,20 +174,7 @@ jobs:
           cargo update
           cargo test --all-features
         env:
-          # Increase property test cases for nightly runs
           PROPTEST_CASES: 128
-
-      - name: Run test-full (all tests) - Fresh Resolve (non-Linux)
-        if: runner.os != 'Linux'
-        run: |
-          cargo update
-          cargo test --all-features
-        env:
-          # Increase property test cases for nightly runs
-          PROPTEST_CASES: 128
-
-      - name: Run doc tests
-        run: cargo test --doc
 
   # ============================================================================
   # PROPERTY TESTS: Dedicated property-based testing job
@@ -147,6 +185,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -191,6 +230,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_lane == 'full')
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       XCHECKER_E2E: "1"
@@ -243,6 +283,7 @@ jobs:
   # ============================================================================
   example-validation:
     name: Example Validation (${{ matrix.os }})
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -281,6 +322,7 @@ jobs:
   # ============================================================================
   walkthrough-validation:
     name: Walkthrough Validation (${{ matrix.os }})
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- **Weekly schedule instead of daily**: Both `test.yml` and `dependency-management.yml` cron triggers changed from `0 2 * * *` (daily) to `0 2 * * 1` (Monday only), cutting scheduled runner usage by ~85%.
- **Schedule runs limited to ubuntu-latest**: Multi-platform matrix jobs (`test-full`, `test-locked`, `test-fresh`) now resolve to `["ubuntu-latest"]` on schedule events, saving 2/3 of runner minutes per scheduled run. Push/PR triggers still run on all 3 platforms.
- **Concurrency groups added**: `group: workflow-ref` with `cancel-in-progress: true` prevents duplicate runs from piling up (e.g., rapid pushes to main).
- **timeout-minutes on every job**: Prevents hung runners from silently consuming the Actions minutes budget. Values range from 5 min (summary jobs) to 30 min (full test builds).
- **Fresh-resolve extracted into its own job**: Previously, `test-full` ran `cargo update` + full tests *after* already running locked tests on every push -- doubling build time. Fresh-resolve is now a separate job that only runs on schedule and manual dispatch, so push builds are ~2x faster.
- **workflow_dispatch platform input**: Maintainers can manually trigger with `platform: ubuntu-only` or `platform: all` to control runner usage.

## Context

All nightly schedule runs were failing -- runners were allocated but never executed steps, likely due to GitHub Actions minutes exhaustion. The scheduled workflows were also building a stale SHA (`5d41a1d`) instead of current main (`e45db2a`), consistent with cached/queued workflow state after hitting the free-tier limit.

## Test plan

- [ ] Verify this PR's own CI run passes (push trigger exercises test-full on all 3 platforms)
- [ ] After merge, manually trigger `test.yml` via workflow_dispatch with `test_lane: full` and `platform: ubuntu-only` to confirm the dispatch input works
- [ ] Confirm next Monday's scheduled run only spawns ubuntu-latest jobs
- [ ] Check GitHub Actions usage page after one week to verify minutes consumption dropped