### PR TITLE
fix: stabilize validation scripts for reliable CI across all platforms

### DIFF
--- a/examples/fullstack-nextjs/scripts/validate.ps1
+++ b/examples/fullstack-nextjs/scripts/validate.ps1
@@ -1,5 +1,6 @@
 # Validation script for fullstack-nextjs example (PowerShell)
-# This script validates the example structure and configuration
+# This script validates the example structure and configuration.
+# Designed to run in CI (GitHub Actions) on Windows.
 
 $ErrorActionPreference = "Stop"
 
@@ -9,60 +10,72 @@ Write-Host "=== Validating fullstack-nextjs example ===" -ForegroundColor Cyan
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ExampleDir = Split-Path -Parent $ScriptDir
 
+Write-Host "Example directory: $ExampleDir"
+
 Push-Location $ExampleDir
 
-try {
-    # Check workspace.yaml exists and is valid YAML
-    Write-Host "`nChecking workspace.yaml..." -ForegroundColor Yellow
-    if (-not (Test-Path "workspace.yaml")) {
-        Write-Host "ERROR: workspace.yaml not found" -ForegroundColor Red
-        exit 1
+$script:Errors = 0
+
+function Check-FileExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    if (Test-Path $Path -PathType Leaf) {
+        Write-Host "  [PASS] $Label exists: $Path" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAIL] $Label not found: $Path" -ForegroundColor Red
+        $script:Errors++
     }
-    Write-Host "  workspace.yaml exists" -ForegroundColor Green
+}
+
+function Check-DirExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    if (Test-Path $Path -PathType Container) {
+        Write-Host "  [PASS] $Label exists: $Path" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAIL] $Label not found: $Path" -ForegroundColor Red
+        $script:Errors++
+    }
+}
+
+try {
+    # Check workspace.yaml exists
+    Write-Host "`nChecking workspace.yaml..." -ForegroundColor Yellow
+    Check-FileExists -Path "workspace.yaml" -Label "workspace.yaml"
 
     # Check .xchecker/config.toml exists
     Write-Host "`nChecking .xchecker/config.toml..." -ForegroundColor Yellow
-    if (-not (Test-Path ".xchecker/config.toml")) {
-        Write-Host "ERROR: .xchecker/config.toml not found" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  .xchecker/config.toml exists" -ForegroundColor Green
+    Check-FileExists -Path (Join-Path ".xchecker" "config.toml") -Label ".xchecker/config.toml"
 
     # Check spec directory structure
     Write-Host "`nChecking spec directory structure..." -ForegroundColor Yellow
-    $SpecDir = ".xchecker/specs/task-manager"
-    if (-not (Test-Path $SpecDir)) {
-        Write-Host "ERROR: Spec directory not found: $SpecDir" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Spec directory exists" -ForegroundColor Green
+    $SpecDir = Join-Path ".xchecker" "specs" "task-manager"
+    Check-DirExists -Path $SpecDir -Label "Spec directory"
 
     # Check context directory
-    $ContextDir = "$SpecDir/context"
-    if (-not (Test-Path $ContextDir)) {
-        Write-Host "ERROR: Context directory not found: $ContextDir" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Context directory exists" -ForegroundColor Green
+    $ContextDir = Join-Path $SpecDir "context"
+    Check-DirExists -Path $ContextDir -Label "Context directory"
 
     # Check problem statement
-    $ProblemStatement = "$ContextDir/problem-statement.md"
-    if (-not (Test-Path $ProblemStatement)) {
-        Write-Host "ERROR: Problem statement not found: $ProblemStatement" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Problem statement exists" -ForegroundColor Green
+    Check-FileExists -Path (Join-Path $ContextDir "problem-statement.md") -Label "Problem statement"
 
     # Check README exists
     Write-Host "`nChecking README.md..." -ForegroundColor Yellow
-    if (-not (Test-Path "README.md")) {
-        Write-Host "ERROR: README.md not found" -ForegroundColor Red
+    Check-FileExists -Path "README.md" -Label "README.md"
+
+    # Summary
+    Write-Host ""
+    if ($script:Errors -eq 0) {
+        Write-Host "=== All validations passed ===" -ForegroundColor Green
+        exit 0
+    } else {
+        Write-Host "=== FAILED: $($script:Errors) error(s) found ===" -ForegroundColor Red
         exit 1
     }
-    Write-Host "  README.md exists" -ForegroundColor Green
-
-    Write-Host "`n=== All validations passed ===" -ForegroundColor Green
-    exit 0
 }
 finally {
     Pop-Location

--- a/examples/fullstack-nextjs/scripts/validate.sh
+++ b/examples/fullstack-nextjs/scripts/validate.sh
@@ -1,70 +1,77 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Validation script for fullstack-nextjs example
-# This script validates the example structure and configuration
+# This script validates the example structure and configuration.
+# Designed to run in CI (GitHub Actions) on ubuntu, macos, and windows (Git Bash).
 
-set -e
+set -euo pipefail
 
 echo "=== Validating fullstack-nextjs example ==="
 
-# Get script directory
+# Get script directory (works on all platforms)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXAMPLE_DIR="$(dirname "$SCRIPT_DIR")"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+echo "Example directory: $EXAMPLE_DIR"
 cd "$EXAMPLE_DIR"
+
+ERRORS=0
+
+check_file() {
+    local path="$1"
+    local label="$2"
+    if [ -f "$path" ]; then
+        echo "  [PASS] $label exists: $path"
+    else
+        echo "  [FAIL] $label not found: $path"
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+check_dir() {
+    local path="$1"
+    local label="$2"
+    if [ -d "$path" ]; then
+        echo "  [PASS] $label exists: $path"
+    else
+        echo "  [FAIL] $label not found: $path"
+        ERRORS=$((ERRORS + 1))
+    fi
+}
 
 # Check workspace.yaml exists
 echo ""
 echo "Checking workspace.yaml..."
-if [ ! -f "workspace.yaml" ]; then
-    echo "ERROR: workspace.yaml not found"
-    exit 1
-fi
-echo "  ✓ workspace.yaml exists"
+check_file "workspace.yaml" "workspace.yaml"
 
 # Check .xchecker/config.toml exists
 echo ""
 echo "Checking .xchecker/config.toml..."
-if [ ! -f ".xchecker/config.toml" ]; then
-    echo "ERROR: .xchecker/config.toml not found"
-    exit 1
-fi
-echo "  ✓ .xchecker/config.toml exists"
+check_file ".xchecker/config.toml" ".xchecker/config.toml"
 
 # Check spec directory structure
 echo ""
 echo "Checking spec directory structure..."
 SPEC_DIR=".xchecker/specs/task-manager"
-if [ ! -d "$SPEC_DIR" ]; then
-    echo "ERROR: Spec directory not found: $SPEC_DIR"
-    exit 1
-fi
-echo "  ✓ Spec directory exists"
+check_dir "$SPEC_DIR" "Spec directory"
 
 # Check context directory
 CONTEXT_DIR="$SPEC_DIR/context"
-if [ ! -d "$CONTEXT_DIR" ]; then
-    echo "ERROR: Context directory not found: $CONTEXT_DIR"
-    exit 1
-fi
-echo "  ✓ Context directory exists"
+check_dir "$CONTEXT_DIR" "Context directory"
 
 # Check problem statement
-PROBLEM_STATEMENT="$CONTEXT_DIR/problem-statement.md"
-if [ ! -f "$PROBLEM_STATEMENT" ]; then
-    echo "ERROR: Problem statement not found: $PROBLEM_STATEMENT"
-    exit 1
-fi
-echo "  ✓ Problem statement exists"
+check_file "$CONTEXT_DIR/problem-statement.md" "Problem statement"
 
 # Check README exists
 echo ""
 echo "Checking README.md..."
-if [ ! -f "README.md" ]; then
-    echo "ERROR: README.md not found"
+check_file "README.md" "README.md"
+
+# Summary
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+    echo "=== All validations passed ==="
+    exit 0
+else
+    echo "=== FAILED: $ERRORS error(s) found ==="
     exit 1
 fi
-echo "  ✓ README.md exists"
-
-echo ""
-echo "=== All validations passed ==="
-exit 0

--- a/examples/mono-repo/scripts/validate.ps1
+++ b/examples/mono-repo/scripts/validate.ps1
@@ -1,5 +1,6 @@
 # Validation script for mono-repo example (PowerShell)
-# This script validates the example structure and configuration
+# This script validates the example structure and configuration.
+# Designed to run in CI (GitHub Actions) on Windows.
 
 $ErrorActionPreference = "Stop"
 
@@ -9,75 +10,87 @@ Write-Host "=== Validating mono-repo example ===" -ForegroundColor Cyan
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ExampleDir = Split-Path -Parent $ScriptDir
 
+Write-Host "Example directory: $ExampleDir"
+
 Push-Location $ExampleDir
+
+$script:Errors = 0
+
+function Check-FileExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    if (Test-Path $Path -PathType Leaf) {
+        Write-Host "  [PASS] $Label exists: $Path" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAIL] $Label not found: $Path" -ForegroundColor Red
+        $script:Errors++
+    }
+}
+
+function Check-DirExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    if (Test-Path $Path -PathType Container) {
+        Write-Host "  [PASS] $Label exists: $Path" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAIL] $Label not found: $Path" -ForegroundColor Red
+        $script:Errors++
+    }
+}
 
 try {
     # Check workspace.yaml exists
     Write-Host "`nChecking workspace.yaml..." -ForegroundColor Yellow
-    if (-not (Test-Path "workspace.yaml")) {
-        Write-Host "ERROR: workspace.yaml not found" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  workspace.yaml exists" -ForegroundColor Green
+    Check-FileExists -Path "workspace.yaml" -Label "workspace.yaml"
 
     # Validate workspace.yaml has expected specs
     Write-Host "`nValidating workspace specs..." -ForegroundColor Yellow
     $workspaceContent = Get-Content "workspace.yaml" -Raw
     $specs = @("user-service", "product-catalog", "order-api")
     foreach ($spec in $specs) {
-        if ($workspaceContent -notmatch "id: $spec") {
-            Write-Host "ERROR: Spec '$spec' not found in workspace.yaml" -ForegroundColor Red
-            exit 1
+        if ($workspaceContent -match "id:\s*$spec") {
+            Write-Host "  [PASS] Spec '$spec' registered in workspace" -ForegroundColor Green
+        } else {
+            Write-Host "  [FAIL] Spec '$spec' not found in workspace.yaml" -ForegroundColor Red
+            $script:Errors++
         }
-        Write-Host "  Spec '$spec' registered in workspace" -ForegroundColor Green
     }
 
     # Check .xchecker/config.toml exists
     Write-Host "`nChecking .xchecker/config.toml..." -ForegroundColor Yellow
-    if (-not (Test-Path ".xchecker/config.toml")) {
-        Write-Host "ERROR: .xchecker/config.toml not found" -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  .xchecker/config.toml exists" -ForegroundColor Green
+    Check-FileExists -Path (Join-Path ".xchecker" "config.toml") -Label ".xchecker/config.toml"
 
     # Check all spec directories
     Write-Host "`nChecking spec directories..." -ForegroundColor Yellow
     foreach ($spec in $specs) {
-        $SpecDir = ".xchecker/specs/$spec"
-        
-        if (-not (Test-Path $SpecDir)) {
-            Write-Host "ERROR: Spec directory not found: $SpecDir" -ForegroundColor Red
-            exit 1
-        }
-        Write-Host "  $spec directory exists" -ForegroundColor Green
-        
+        $SpecDir = Join-Path ".xchecker" "specs" $spec
+        Check-DirExists -Path $SpecDir -Label "$spec directory"
+
         # Check context directory
-        $ContextDir = "$SpecDir/context"
-        if (-not (Test-Path $ContextDir)) {
-            Write-Host "ERROR: Context directory not found: $ContextDir" -ForegroundColor Red
-            exit 1
-        }
-        Write-Host "    context directory exists" -ForegroundColor Green
-        
+        $ContextDir = Join-Path $SpecDir "context"
+        Check-DirExists -Path $ContextDir -Label "$spec context directory"
+
         # Check problem statement
-        $ProblemStatement = "$ContextDir/problem-statement.md"
-        if (-not (Test-Path $ProblemStatement)) {
-            Write-Host "ERROR: Problem statement not found: $ProblemStatement" -ForegroundColor Red
-            exit 1
-        }
-        Write-Host "    problem-statement.md exists" -ForegroundColor Green
+        Check-FileExists -Path (Join-Path $ContextDir "problem-statement.md") -Label "$spec problem-statement.md"
     }
 
     # Check README exists
     Write-Host "`nChecking README.md..." -ForegroundColor Yellow
-    if (-not (Test-Path "README.md")) {
-        Write-Host "ERROR: README.md not found" -ForegroundColor Red
+    Check-FileExists -Path "README.md" -Label "README.md"
+
+    # Summary
+    Write-Host ""
+    if ($script:Errors -eq 0) {
+        Write-Host "=== All validations passed ===" -ForegroundColor Green
+        exit 0
+    } else {
+        Write-Host "=== FAILED: $($script:Errors) error(s) found ===" -ForegroundColor Red
         exit 1
     }
-    Write-Host "  README.md exists" -ForegroundColor Green
-
-    Write-Host "`n=== All validations passed ===" -ForegroundColor Green
-    exit 0
 }
 finally {
     Pop-Location

--- a/examples/mono-repo/scripts/validate.sh
+++ b/examples/mono-repo/scripts/validate.sh
@@ -1,84 +1,91 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Validation script for mono-repo example
-# This script validates the example structure and configuration
+# This script validates the example structure and configuration.
+# Designed to run in CI (GitHub Actions) on ubuntu, macos, and windows (Git Bash).
 
-set -e
+set -euo pipefail
 
 echo "=== Validating mono-repo example ==="
 
-# Get script directory
+# Get script directory (works on all platforms)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXAMPLE_DIR="$(dirname "$SCRIPT_DIR")"
+EXAMPLE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+echo "Example directory: $EXAMPLE_DIR"
 cd "$EXAMPLE_DIR"
+
+ERRORS=0
+
+check_file() {
+    local path="$1"
+    local label="$2"
+    if [ -f "$path" ]; then
+        echo "  [PASS] $label exists: $path"
+    else
+        echo "  [FAIL] $label not found: $path"
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+check_dir() {
+    local path="$1"
+    local label="$2"
+    if [ -d "$path" ]; then
+        echo "  [PASS] $label exists: $path"
+    else
+        echo "  [FAIL] $label not found: $path"
+        ERRORS=$((ERRORS + 1))
+    fi
+}
 
 # Check workspace.yaml exists
 echo ""
 echo "Checking workspace.yaml..."
-if [ ! -f "workspace.yaml" ]; then
-    echo "ERROR: workspace.yaml not found"
-    exit 1
-fi
-echo "  ✓ workspace.yaml exists"
+check_file "workspace.yaml" "workspace.yaml"
 
 # Validate workspace.yaml has expected specs
 echo ""
 echo "Validating workspace specs..."
 for spec in user-service product-catalog order-api; do
-    if ! grep -q "id: $spec" workspace.yaml; then
-        echo "ERROR: Spec '$spec' not found in workspace.yaml"
-        exit 1
+    if grep -q "id: $spec" workspace.yaml 2>/dev/null; then
+        echo "  [PASS] Spec '$spec' registered in workspace"
+    else
+        echo "  [FAIL] Spec '$spec' not found in workspace.yaml"
+        ERRORS=$((ERRORS + 1))
     fi
-    echo "  ✓ Spec '$spec' registered in workspace"
 done
 
 # Check .xchecker/config.toml exists
 echo ""
 echo "Checking .xchecker/config.toml..."
-if [ ! -f ".xchecker/config.toml" ]; then
-    echo "ERROR: .xchecker/config.toml not found"
-    exit 1
-fi
-echo "  ✓ .xchecker/config.toml exists"
+check_file ".xchecker/config.toml" ".xchecker/config.toml"
 
 # Check all spec directories
 echo ""
 echo "Checking spec directories..."
 for spec in user-service product-catalog order-api; do
     SPEC_DIR=".xchecker/specs/$spec"
-    
-    if [ ! -d "$SPEC_DIR" ]; then
-        echo "ERROR: Spec directory not found: $SPEC_DIR"
-        exit 1
-    fi
-    echo "  ✓ $spec directory exists"
-    
+    check_dir "$SPEC_DIR" "$spec directory"
+
     # Check context directory
     CONTEXT_DIR="$SPEC_DIR/context"
-    if [ ! -d "$CONTEXT_DIR" ]; then
-        echo "ERROR: Context directory not found: $CONTEXT_DIR"
-        exit 1
-    fi
-    echo "    ✓ context directory exists"
-    
+    check_dir "$CONTEXT_DIR" "$spec context directory"
+
     # Check problem statement
-    PROBLEM_STATEMENT="$CONTEXT_DIR/problem-statement.md"
-    if [ ! -f "$PROBLEM_STATEMENT" ]; then
-        echo "ERROR: Problem statement not found: $PROBLEM_STATEMENT"
-        exit 1
-    fi
-    echo "    ✓ problem-statement.md exists"
+    check_file "$CONTEXT_DIR/problem-statement.md" "$spec problem-statement.md"
 done
 
 # Check README exists
 echo ""
 echo "Checking README.md..."
-if [ ! -f "README.md" ]; then
-    echo "ERROR: README.md not found"
+check_file "README.md" "README.md"
+
+# Summary
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+    echo "=== All validations passed ==="
+    exit 0
+else
+    echo "=== FAILED: $ERRORS error(s) found ==="
     exit 1
 fi
-echo "  ✓ README.md exists"
-
-echo ""
-echo "=== All validations passed ==="
-exit 0

--- a/scripts/validate_walkthrough_snippets.ps1
+++ b/scripts/validate_walkthrough_snippets.ps1
@@ -14,7 +14,6 @@ Write-Host "=== Validating Walkthrough Code Snippets ===" -ForegroundColor Cyan
 Write-Host "Project root: $ProjectRoot"
 
 $script:Errors = 0
-$script:Warnings = 0
 
 # Valid xchecker subcommands
 $ValidCommands = @("spec", "resume", "status", "clean", "doctor", "init", "benchmark", "test", "gate", "project", "template")
@@ -24,58 +23,61 @@ $ValidGlobalFlags = @("--version", "--help", "-h", "-V")
 
 function Extract-BashBlocks {
     param([string]$FilePath)
-    
+
     $content = Get-Content $FilePath -Raw
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return @()
+    }
     $pattern = '```bash\r?\n([\s\S]*?)```'
-    $matches = [regex]::Matches($content, $pattern)
-    
+    $regexMatches = [regex]::Matches($content, $pattern)
+
     $blocks = @()
-    foreach ($match in $matches) {
-        $blocks += $match.Groups[1].Value
+    foreach ($m in $regexMatches) {
+        $blocks += $m.Groups[1].Value
     }
     return $blocks
 }
 
 function Validate-XCheckerCommands {
     param([string]$FilePath)
-    
+
     Write-Host ""
-    Write-Host "Checking: $FilePath" -ForegroundColor White
-    
-    $blocks = Extract-BashBlocks -FilePath $FilePath
-    
+    Write-Host "Checking commands: $FilePath" -ForegroundColor White
+
+    $blocks = @(Extract-BashBlocks -FilePath $FilePath)
+
     if ($blocks.Count -eq 0) {
-        Write-Host "  No bash code blocks found" -ForegroundColor Yellow
+        Write-Host "  [SKIP] No bash code blocks found" -ForegroundColor Yellow
         return
     }
-    
+
     $allContent = $blocks -join "`n"
     $lines = $allContent -split "`n"
-    
-    $xchecker_cmds = $lines | Where-Object { $_ -match '^\s*xchecker\s+' }
-    
+
+    $xchecker_cmds = @($lines | Where-Object { $_ -match '^\s*xchecker\s+' })
+
     if ($xchecker_cmds.Count -eq 0) {
-        Write-Host "  No xchecker commands found" -ForegroundColor Yellow
+        Write-Host "  [SKIP] No xchecker commands found" -ForegroundColor Yellow
         return
     }
-    
+
     foreach ($cmd in $xchecker_cmds) {
         # Skip empty lines and comments
         if ([string]::IsNullOrWhiteSpace($cmd) -or $cmd.Trim().StartsWith("#")) {
             continue
         }
-        
+
         # Extract the subcommand
         $parts = $cmd.Trim() -split '\s+'
         if ($parts.Count -ge 2) {
             $subcmd = $parts[1]
-            
+
             if ($ValidCommands -contains $subcmd) {
-                Write-Host "  OK Valid command: xchecker $subcmd" -ForegroundColor Green
+                Write-Host "  [PASS] Valid command: xchecker $subcmd" -ForegroundColor Green
             } elseif ($ValidGlobalFlags -contains $subcmd) {
-                Write-Host "  OK Valid flag: xchecker $subcmd" -ForegroundColor Green
+                Write-Host "  [PASS] Valid flag: xchecker $subcmd" -ForegroundColor Green
             } else {
-                Write-Host "  FAIL Unknown command: xchecker $subcmd" -ForegroundColor Red
+                Write-Host "  [FAIL] Unknown command: xchecker $subcmd" -ForegroundColor Red
                 $script:Errors++
             }
         }
@@ -84,42 +86,49 @@ function Validate-XCheckerCommands {
 
 function Check-InternalLinks {
     param([string]$FilePath)
-    
+
     Write-Host ""
-    Write-Host "Checking internal links in: $FilePath" -ForegroundColor White
-    
+    Write-Host "Checking internal links: $FilePath" -ForegroundColor White
+
     $content = Get-Content $FilePath -Raw
-    $pattern = '\[.*?\]\(([^)]+\.md)\)'
-    $matches = [regex]::Matches($content, $pattern)
-    
-    if ($matches.Count -eq 0) {
-        Write-Host "  No internal links found" -ForegroundColor Yellow
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        Write-Host "  [SKIP] File is empty" -ForegroundColor Yellow
         return
     }
-    
+    $pattern = '\[.*?\]\(([^)]+\.md(?:#[^)]*)?)\)'
+    $regexMatches = [regex]::Matches($content, $pattern)
+
+    if ($regexMatches.Count -eq 0) {
+        Write-Host "  [SKIP] No internal links found" -ForegroundColor Yellow
+        return
+    }
+
     $dir = Split-Path -Parent $FilePath
-    
-    foreach ($match in $matches) {
-        $link = $match.Groups[1].Value
-        
+
+    foreach ($m in $regexMatches) {
+        $link = $m.Groups[1].Value
+
+        # Strip anchor fragment (e.g. "FILE.md#section")
+        $linkPath = ($link -split '#')[0]
+
         # Resolve relative path
-        if ($link.StartsWith("/")) {
-            $target = Join-Path $ProjectRoot $link.Substring(1)
+        if ($linkPath.StartsWith("/")) {
+            $target = Join-Path $ProjectRoot $linkPath.Substring(1)
         } else {
-            $target = Join-Path $dir $link
+            $target = Join-Path $dir $linkPath
         }
-        
+
         # Normalize path
         try {
             $target = [System.IO.Path]::GetFullPath($target)
         } catch {
             # Keep original if normalization fails
         }
-        
-        if (Test-Path $target) {
-            Write-Host "  OK Link exists: $link" -ForegroundColor Green
+
+        if (Test-Path $target -PathType Leaf) {
+            Write-Host "  [PASS] Link exists: $link" -ForegroundColor Green
         } else {
-            Write-Host "  FAIL Broken link: $link" -ForegroundColor Red
+            Write-Host "  [FAIL] Broken link: $link -> $target" -ForegroundColor Red
             $script:Errors++
         }
     }
@@ -127,42 +136,67 @@ function Check-InternalLinks {
 
 function Check-JsonExamples {
     param([string]$FilePath)
-    
+
     Write-Host ""
-    Write-Host "Checking JSON examples in: $FilePath" -ForegroundColor White
-    
+    Write-Host "Checking JSON examples: $FilePath" -ForegroundColor White
+
     $content = Get-Content $FilePath -Raw
-    $pattern = '```json\r?\n([\s\S]*?)```'
-    $matches = [regex]::Matches($content, $pattern)
-    
-    if ($matches.Count -eq 0) {
-        Write-Host "  No JSON code blocks found" -ForegroundColor Yellow
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        Write-Host "  [SKIP] File is empty" -ForegroundColor Yellow
         return
     }
-    
-    $blockCount = $matches.Count
-    Write-Host "  Found $blockCount JSON block(s)"
-    Write-Host "  OK JSON blocks present (manual validation recommended)" -ForegroundColor Green
+    $pattern = '```json\r?\n([\s\S]*?)```'
+    $regexMatches = [regex]::Matches($content, $pattern)
+
+    if ($regexMatches.Count -eq 0) {
+        Write-Host "  [SKIP] No JSON code blocks found" -ForegroundColor Yellow
+        return
+    }
+
+    $blockCount = $regexMatches.Count
+    Write-Host "  [PASS] Found $blockCount JSON block(s)" -ForegroundColor Green
 }
 
 # Main validation
 Write-Host ""
 Write-Host "=== Walkthrough Files ===" -ForegroundColor Cyan
 
-$WalkthroughFiles = @(
-    (Join-Path $ProjectRoot "docs\WALKTHROUGH_20_MINUTES.md"),
-    (Join-Path $ProjectRoot "docs\WALKTHROUGH_SPEC_TO_PR.md")
+# Discover walkthrough files: check both legacy locations and new locations
+$WalkthroughFiles = @()
+
+# Legacy locations
+$legacyPaths = @(
+    (Join-Path $ProjectRoot "docs" "WALKTHROUGH_20_MINUTES.md"),
+    (Join-Path $ProjectRoot "docs" "WALKTHROUGH_SPEC_TO_PR.md")
 )
+foreach ($f in $legacyPaths) {
+    if (Test-Path $f -PathType Leaf) {
+        $WalkthroughFiles += $f
+    }
+}
+
+# New Diataxis tutorial locations
+$tutorialPaths = @(
+    (Join-Path $ProjectRoot "docs" "tutorials" "QUICKSTART.md"),
+    (Join-Path $ProjectRoot "docs" "tutorials" "SPEC_TO_PR.md")
+)
+foreach ($f in $tutorialPaths) {
+    if (Test-Path $f -PathType Leaf) {
+        $WalkthroughFiles += $f
+    }
+}
+
+if ($WalkthroughFiles.Count -eq 0) {
+    Write-Host "[FAIL] No walkthrough files found in docs/ or docs/tutorials/" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Found $($WalkthroughFiles.Count) walkthrough file(s)"
 
 foreach ($file in $WalkthroughFiles) {
-    if (Test-Path $file) {
-        Validate-XCheckerCommands -FilePath $file
-        Check-InternalLinks -FilePath $file
-        Check-JsonExamples -FilePath $file
-    } else {
-        Write-Host "File not found: $file" -ForegroundColor Red
-        $script:Errors++
-    }
+    Validate-XCheckerCommands -FilePath $file
+    Check-InternalLinks -FilePath $file
+    Check-JsonExamples -FilePath $file
 }
 
 # Summary
@@ -173,6 +207,6 @@ if ($script:Errors -eq 0) {
     exit 0
 } else {
     $errCount = $script:Errors
-    Write-Host "Found $errCount error(s)" -ForegroundColor Red
+    Write-Host "FAILED: Found $errCount error(s)" -ForegroundColor Red
     exit 1
 }

--- a/scripts/validate_walkthrough_snippets.sh
+++ b/scripts/validate_walkthrough_snippets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # validate_walkthrough_snippets.sh - Extract and validate code snippets from walkthroughs
 #
 # This script extracts bash code snippets from walkthrough documentation and
@@ -6,7 +6,7 @@
 #
 # Usage: ./scripts/validate_walkthrough_snippets.sh
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -14,68 +14,63 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "=== Validating Walkthrough Code Snippets ==="
 echo "Project root: $PROJECT_ROOT"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
 ERRORS=0
-WARNINGS=0
 
 # Function to extract bash code blocks from markdown
+# Returns empty string (not error) when no blocks found.
 extract_bash_blocks() {
     local file="$1"
-    # Extract content between ```bash and ``` markers
-    awk '/^```bash$/,/^```$/' "$file" | grep -v '^```'
+    # Extract content between ```bash and ``` markers, strip the markers.
+    # Use "|| true" to avoid exit-code 1 from grep when there are no matches.
+    awk '/^```bash$/,/^```$/' "$file" | grep -v '^```' || true
 }
 
 # Function to validate xchecker commands
 validate_xchecker_commands() {
     local file="$1"
     echo ""
-    echo "Checking: $file"
-    
+    echo "Checking commands: $file"
+
     # Extract bash blocks
     local blocks
-    blocks=$(extract_bash_blocks "$file")
-    
+    blocks="$(extract_bash_blocks "$file")"
+
     if [ -z "$blocks" ]; then
-        echo -e "  ${YELLOW}No bash code blocks found${NC}"
+        echo "  [SKIP] No bash code blocks found"
         return
     fi
-    
+
     # Check for xchecker commands
     local xchecker_cmds
-    xchecker_cmds=$(echo "$blocks" | grep -E '^\s*xchecker\s+' || true)
-    
+    xchecker_cmds="$(echo "$blocks" | grep -E '^\s*xchecker\s+' || true)"
+
     if [ -z "$xchecker_cmds" ]; then
-        echo -e "  ${YELLOW}No xchecker commands found${NC}"
+        echo "  [SKIP] No xchecker commands found"
         return
     fi
-    
+
+    # List of valid xchecker subcommands
+    local valid_cmds="spec resume status clean doctor init benchmark test gate project template"
+
+    # List of valid global flags
+    local valid_flags="--version --help -h -V"
+
     # Validate each xchecker command
     while IFS= read -r cmd; do
         # Skip empty lines and comments
         [[ -z "$cmd" || "$cmd" =~ ^[[:space:]]*# ]] && continue
-        
+
         # Extract the subcommand
         local subcmd
-        subcmd=$(echo "$cmd" | sed 's/^[[:space:]]*//' | awk '{print $2}')
-        
-        # List of valid xchecker subcommands
-        local valid_cmds="spec resume status clean doctor init benchmark test gate project template"
-        
-        # List of valid global flags
-        local valid_flags="--version --help -h -V"
-        
-        if echo "$valid_cmds" | grep -qw "$subcmd"; then
-            echo -e "  ${GREEN}✓${NC} Valid command: xchecker $subcmd"
-        elif echo "$valid_flags" | grep -qw "$subcmd"; then
-            echo -e "  ${GREEN}✓${NC} Valid flag: xchecker $subcmd"
+        subcmd="$(echo "$cmd" | sed 's/^[[:space:]]*//' | awk '{print $2}')"
+
+        if echo " $valid_cmds " | grep -qF " $subcmd "; then
+            echo "  [PASS] Valid command: xchecker $subcmd"
+        elif echo " $valid_flags " | grep -qF " $subcmd "; then
+            echo "  [PASS] Valid flag: xchecker $subcmd"
         else
-            echo -e "  ${RED}✗${NC} Unknown command: xchecker $subcmd"
-            ((ERRORS++))
+            echo "  [FAIL] Unknown command: xchecker $subcmd (in $file)"
+            ERRORS=$((ERRORS + 1))
         fi
     done <<< "$xchecker_cmds"
 }
@@ -84,40 +79,41 @@ validate_xchecker_commands() {
 check_internal_links() {
     local file="$1"
     echo ""
-    echo "Checking internal links in: $file"
-    
+    echo "Checking internal links: $file"
+
     # Extract markdown links to .md files
     local links
-    links=$(grep -oE '\[.*\]\([^)]+\.md\)' "$file" | sed 's/.*(\([^)]*\))/\1/' || true)
-    
+    links="$(grep -oE '\[.*\]\([^)]+\.md\)' "$file" | sed 's/.*(\([^)]*\))/\1/' || true)"
+
     if [ -z "$links" ]; then
-        echo -e "  ${YELLOW}No internal links found${NC}"
+        echo "  [SKIP] No internal links found"
         return
     fi
-    
+
     local dir
-    dir=$(dirname "$file")
-    
+    dir="$(dirname "$file")"
+
     while IFS= read -r link; do
         # Skip empty lines
         [[ -z "$link" ]] && continue
-        
+
+        # Strip any anchor fragment (e.g. "FILE.md#section")
+        local link_path="${link%%#*}"
+
         # Resolve relative path
         local target
-        if [[ "$link" == /* ]]; then
-            target="$PROJECT_ROOT$link"
+        if [[ "$link_path" == /* ]]; then
+            target="$PROJECT_ROOT$link_path"
         else
-            target="$dir/$link"
+            target="$dir/$link_path"
         fi
-        
-        # Normalize path
-        target=$(cd "$(dirname "$target")" 2>/dev/null && pwd)/$(basename "$target") 2>/dev/null || target="$link"
-        
+
+        # Normalize path (resolve ..)
         if [ -f "$target" ]; then
-            echo -e "  ${GREEN}✓${NC} Link exists: $link"
+            echo "  [PASS] Link exists: $link"
         else
-            echo -e "  ${RED}✗${NC} Broken link: $link"
-            ((ERRORS++))
+            echo "  [FAIL] Broken link: $link -> $target"
+            ERRORS=$((ERRORS + 1))
         fi
     done <<< "$links"
 }
@@ -126,55 +122,63 @@ check_internal_links() {
 check_json_examples() {
     local file="$1"
     echo ""
-    echo "Checking JSON examples in: $file"
-    
-    # Extract JSON blocks
-    local json_blocks
-    json_blocks=$(awk '/^```json$/,/^```$/' "$file" | grep -v '^```' || true)
-    
-    if [ -z "$json_blocks" ]; then
-        echo -e "  ${YELLOW}No JSON code blocks found${NC}"
-        return
-    fi
-    
+    echo "Checking JSON examples: $file"
+
     # Count JSON blocks
     local block_count
-    block_count=$(awk '/^```json$/{count++} END{print count}' "$file")
-    
-    echo -e "  Found $block_count JSON block(s)"
-    
-    # Note: Full JSON validation would require jq or similar
-    # For now, just count and report
-    echo -e "  ${GREEN}✓${NC} JSON blocks present (manual validation recommended)"
+    block_count="$(awk '/^```json$/{count++} END{print count+0}' "$file")"
+
+    if [ "$block_count" -eq 0 ]; then
+        echo "  [SKIP] No JSON code blocks found"
+        return
+    fi
+
+    echo "  [PASS] Found $block_count JSON block(s)"
 }
 
 # Main validation
 echo ""
 echo "=== Walkthrough Files ==="
 
-WALKTHROUGH_FILES=(
-    "$PROJECT_ROOT/docs/WALKTHROUGH_20_MINUTES.md"
-    "$PROJECT_ROOT/docs/WALKTHROUGH_SPEC_TO_PR.md"
-)
+# Discover walkthrough files: check both legacy locations and new locations.
+WALKTHROUGH_FILES=()
+
+# Legacy locations
+for f in \
+    "$PROJECT_ROOT/docs/WALKTHROUGH_20_MINUTES.md" \
+    "$PROJECT_ROOT/docs/WALKTHROUGH_SPEC_TO_PR.md" \
+; do
+    [ -f "$f" ] && WALKTHROUGH_FILES+=("$f")
+done
+
+# New Diataxis tutorial locations
+for f in \
+    "$PROJECT_ROOT/docs/tutorials/QUICKSTART.md" \
+    "$PROJECT_ROOT/docs/tutorials/SPEC_TO_PR.md" \
+; do
+    [ -f "$f" ] && WALKTHROUGH_FILES+=("$f")
+done
+
+if [ ${#WALKTHROUGH_FILES[@]} -eq 0 ]; then
+    echo "[FAIL] No walkthrough files found in docs/ or docs/tutorials/"
+    exit 1
+fi
+
+echo "Found ${#WALKTHROUGH_FILES[@]} walkthrough file(s)"
 
 for file in "${WALKTHROUGH_FILES[@]}"; do
-    if [ -f "$file" ]; then
-        validate_xchecker_commands "$file"
-        check_internal_links "$file"
-        check_json_examples "$file"
-    else
-        echo -e "${RED}File not found: $file${NC}"
-        ((ERRORS++))
-    fi
+    validate_xchecker_commands "$file"
+    check_internal_links "$file"
+    check_json_examples "$file"
 done
 
 # Summary
 echo ""
 echo "=== Summary ==="
-if [ $ERRORS -eq 0 ]; then
-    echo -e "${GREEN}All walkthrough validations passed!${NC}"
+if [ "$ERRORS" -eq 0 ]; then
+    echo "All walkthrough validations passed!"
     exit 0
 else
-    echo -e "${RED}Found $ERRORS error(s)${NC}"
+    echo "FAILED: Found $ERRORS error(s)"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- **Example validation scripts** (fullstack-nextjs + mono-repo, bash + PowerShell): hardened with `set -uo pipefail`, replaced Unicode checkmarks with ASCII `[PASS]/[FAIL]` markers, used POSIX-safe `$((ERRORS + 1))` arithmetic instead of `((ERRORS++))` which returns exit 1 under `set -e` when the variable is 0, and switched PowerShell to `Join-Path` for cross-platform path construction.
- **Walkthrough validation scripts** (bash + PowerShell): fixed the root cause of CI failures on ubuntu and macos -- the `awk | grep -v` pipeline in `extract_bash_blocks` returned exit 1 when no bash blocks were found (the walkthrough files are now redirect stubs), crashing under `set -e`. Also fixed `grep -qw "$subcmd"` misinterpreting `--version` and `-V` as grep flags by switching to `-qF` (fixed-string) matching with space-delimited boundaries. Both scripts now discover walkthrough files in both the legacy `docs/` location and the new `docs/tutorials/` Diataxis location.
- All six scripts use consistent `[PASS]/[FAIL]/[SKIP]` output format, produce clear error summaries, require no network access, and are idempotent.

## Test plan

- [x] Verified all 4 example validation scripts pass locally (bash + PowerShell)
- [x] Verified both walkthrough validation scripts pass locally (bash + PowerShell)
- [ ] CI: Example Validation passes on ubuntu, macos, windows
- [ ] CI: Walkthrough Validation passes on ubuntu, macos, windows