### PR TITLE
Add governed Clippy policy baseline, MSRV 1.93, xtask gate, and policy ledgers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run -p xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,6 +4611,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "xtask",
     ".",
     "crates/xchecker-gate",
     "crates/xchecker-phase-api",
@@ -33,12 +34,137 @@ members = [
 [workspace.package]
 version = "1.2.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EffortlessMetrics/xchecker"
 homepage = "https://github.com/EffortlessMetrics/xchecker"
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["cli", "spec", "requirements", "workflow", "automation"]
+
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.dependencies]
 # Internal crates (27 total)
@@ -124,7 +250,7 @@ proptest = "1.9.0"
 name = "xchecker"
 version = "1.2.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.93"
 description = "Spec pipeline with receipts and gateable JSON contracts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EffortlessMetrics/xchecker"
@@ -146,6 +272,9 @@ include = [
     "/src/**",
     "/tests/**",
 ]
+
+[lints]
+workspace = true
 
 [features]
 test-utils = ["xchecker-utils/test-utils", "xchecker-engine/test-utils"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+# Repository-local Clippy configuration for xchecker.
+#
+# This file intentionally contains no test carveouts such as
+# `allow-unwrap-in-tests`, `allow-expect-in-tests`, `allow-panic-in-tests`,
+# `allow-indexing-slicing-in-tests`, or `allow-dbg-in-tests`.
+#
+# Domain-specific disallowed methods/types/macros belong here once they are
+# needed. Baseline lint levels live in Cargo.toml and policy/clippy-lints.toml.

--- a/crates/xchecker-benchmark/Cargo.toml
+++ b/crates/xchecker-benchmark/Cargo.toml
@@ -19,3 +19,6 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/xchecker-cli/Cargo.toml
+++ b/crates/xchecker-cli/Cargo.toml
@@ -19,3 +19,6 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-config/Cargo.toml
+++ b/crates/xchecker-config/Cargo.toml
@@ -26,3 +26,6 @@ camino = { workspace = true }
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-doctor/Cargo.toml
+++ b/crates/xchecker-doctor/Cargo.toml
@@ -26,3 +26,6 @@ clap = { workspace = true }
 regex = { workspace = true }
 toml = { workspace = true }
 strum = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-engine/Cargo.toml
+++ b/crates/xchecker-engine/Cargo.toml
@@ -58,3 +58,6 @@ toml = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 dunce = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-error-redaction/Cargo.toml
+++ b/crates/xchecker-error-redaction/Cargo.toml
@@ -13,3 +13,6 @@ keywords.workspace = true
 [dependencies]
 xchecker-utils = { workspace = true }
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-error-reporter/Cargo.toml
+++ b/crates/xchecker-error-reporter/Cargo.toml
@@ -21,3 +21,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 # For testing
 xchecker-utils = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/xchecker-extraction/Cargo.toml
+++ b/crates/xchecker-extraction/Cargo.toml
@@ -12,3 +12,6 @@ keywords.workspace = true
 
 [dependencies]
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-fixup-model/Cargo.toml
+++ b/crates/xchecker-fixup-model/Cargo.toml
@@ -12,3 +12,6 @@ keywords.workspace = true
 
 [dependencies]
 # No external dependencies - this is a pure types crate
+
+[lints]
+workspace = true

--- a/crates/xchecker-gate/Cargo.toml
+++ b/crates/xchecker-gate/Cargo.toml
@@ -27,3 +27,6 @@ xchecker-receipt = { workspace = true }
 tempfile = { workspace = true }
 serial_test = "3.3.1"
 xchecker-utils = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/xchecker-hooks/Cargo.toml
+++ b/crates/xchecker-hooks/Cargo.toml
@@ -25,3 +25,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-llm/Cargo.toml
+++ b/crates/xchecker-llm/Cargo.toml
@@ -30,3 +30,6 @@ xchecker-config = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-lock/Cargo.toml
+++ b/crates/xchecker-lock/Cargo.toml
@@ -31,3 +31,6 @@ libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/crates/xchecker-packet/Cargo.toml
+++ b/crates/xchecker-packet/Cargo.toml
@@ -24,3 +24,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-phase-api/Cargo.toml
+++ b/crates/xchecker-phase-api/Cargo.toml
@@ -21,3 +21,6 @@ xchecker-utils = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-phases/Cargo.toml
+++ b/crates/xchecker-phases/Cargo.toml
@@ -29,3 +29,6 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/xchecker-prompt-template/Cargo.toml
+++ b/crates/xchecker-prompt-template/Cargo.toml
@@ -17,3 +17,6 @@ xchecker-utils = { workspace = true }
 # External dependencies
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-receipt/Cargo.toml
+++ b/crates/xchecker-receipt/Cargo.toml
@@ -23,3 +23,6 @@ serde_json_canonicalizer = { workspace = true }
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-redaction/Cargo.toml
+++ b/crates/xchecker-redaction/Cargo.toml
@@ -20,3 +20,6 @@ once_cell = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-runner/Cargo.toml
+++ b/crates/xchecker-runner/Cargo.toml
@@ -31,3 +31,6 @@ workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-selectors/Cargo.toml
+++ b/crates/xchecker-selectors/Cargo.toml
@@ -17,3 +17,6 @@ xchecker-utils = { workspace = true }
 
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/xchecker-status/Cargo.toml
+++ b/crates/xchecker-status/Cargo.toml
@@ -27,3 +27,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-templates/Cargo.toml
+++ b/crates/xchecker-templates/Cargo.toml
@@ -17,3 +17,6 @@ xchecker-utils = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-tui/Cargo.toml
+++ b/crates/xchecker-tui/Cargo.toml
@@ -24,3 +24,6 @@ ratatui = { workspace = true }
 [dev-dependencies]
 # For testing
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-utils/Cargo.toml
+++ b/crates/xchecker-utils/Cargo.toml
@@ -53,3 +53,6 @@ dunce = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true
+
+[lints]
+workspace = true

--- a/crates/xchecker-validation/Cargo.toml
+++ b/crates/xchecker-validation/Cargo.toml
@@ -13,3 +13,6 @@ keywords.workspace = true
 [dependencies]
 xchecker-utils = { workspace = true }
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/xchecker-workspace/Cargo.toml
+++ b/crates/xchecker-workspace/Cargo.toml
@@ -21,3 +21,6 @@ serde_yaml = { workspace = true }
 [dev-dependencies]
 xchecker-utils = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,88 @@
+# Effortless Metrics Clippy Policy
+
+xchecker uses the shared Effortless Metrics Rust lint model: one governed
+workspace lint baseline, explicit policy ledgers, and expiring debt instead of
+repo-local lint taste.
+
+## Goals
+
+The baseline is designed to make the workspace:
+
+- panic-free in production and tests;
+- resistant to swallowed work, ignored results, and dropped futures;
+- safe by default around AST, parser, UTF-8, slice, filesystem, process, async,
+  and numeric boundaries;
+- explicit about every suppression; and
+- ready for planned Rust 1.94 and 1.95 lint flips before the MSRV changes.
+
+## Workspace baseline
+
+The active lint levels live in the root `Cargo.toml` under
+`[workspace.lints.rust]` and `[workspace.lints.clippy]`. Every package must
+inherit them with:
+
+```toml
+[lints]
+workspace = true
+```
+
+The machine-readable source of truth is `policy/clippy-lints.toml`. The xtask
+policy gate checks that the active policy ledger matches the root Cargo lint
+blocks and that planned 1.94/1.95 lints remain planned until the workspace MSRV
+is bumped.
+
+## No test carveouts
+
+`clippy.toml` must not contain test carveouts such as:
+
+```toml
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-dbg-in-tests = true
+```
+
+The standard is workspace panic-free, not only production panic-free. Tests
+should return `Result` and use checked assertions/helpers instead of `unwrap`,
+`expect`, `panic!`, or indexing shortcuts.
+
+## Suppression style
+
+New suppressions should use `#[expect(..., reason = "...")]`, scoped to the
+smallest item or expression that needs the exception. Broad `#[allow(...)]`
+attributes are treated as debt and must be represented in
+`policy/clippy-debt.toml` with:
+
+- `lint`
+- `path`
+- `owner`
+- `reason`
+- `expires`
+
+Existing suppressions were captured as temporary debt during the initial policy
+rollout. Follow-up PRs should migrate them to narrow `#[expect]` attributes or
+remove the underlying lint violation.
+
+## Policy files
+
+- `policy/clippy-lints.toml` tracks active lint levels and planned Rust 1.94/1.95
+  flips.
+- `policy/clippy-debt.toml` tracks temporary suppressions and expires them.
+- `policy/no-panic-allowlist.toml` reserves the semantic no-panic allowlist
+  schema: identity is `path + family + selector`; `last_seen` is advisory.
+- `policy/non-rust-allowlist.toml` records non-Rust surfaces with owner, reason,
+  classification, and CI coverage.
+- `clippy.toml` is only for repo-local Clippy configuration such as disallowed
+  methods/types/macros. It is not for weakening the baseline.
+
+## Gate
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate verifies MSRV alignment, workspace lint inheritance, ledger consistency,
+absence of Clippy test carveouts, planned upgrade flips, and non-expired debt.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,2157 @@
+schema = 1
+
+# Existing suppression debt captured during the initial strict Clippy policy rollout.
+# New suppressions should prefer `#[expect(..., reason = "...")]`; these entries
+# keep current carveouts visible until follow-up cleanup PRs migrate them.
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "src/cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 1011
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "src/cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 2141
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "src/cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 2736
+
+[[debt]]
+lint = "clippy::items_after_test_module"
+path = "src/cli.rs"
+owner = "xchecker-maintainers"
+reason = "Test helper functions defined after tests is intentional"
+expires = "2026-08-01"
+last_seen_line = 3351
+
+[[debt]]
+lint = "clippy::await_holding_lock"
+path = "src/cli.rs"
+owner = "xchecker-maintainers"
+reason = "Test synchronization using mutex guards across awaits is intentional"
+expires = "2026-08-01"
+last_seen_line = 3352
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/claude_cli.rs"
+owner = "xchecker-maintainers"
+reason = "Will be used for validation and error reporting"
+expires = "2026-08-01"
+last_seen_line = 19
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/claude_cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 321
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/http_client.rs"
+owner = "xchecker-maintainers"
+reason = "Used by integration tests via pub use in mod.rs"
+expires = "2026-08-01"
+last_seen_line = 217
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-llm/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 23
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-llm/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Used by integration tests in tests/property_based_tests.rs"
+expires = "2026-08-01"
+last_seen_line = 37
+
+[[debt]]
+lint = "clippy::await_holding_lock"
+path = "crates/xchecker-llm/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Test synchronization using mutex guards across awaits is intentional"
+expires = "2026-08-01"
+last_seen_line = 544
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for LLM abstraction"
+expires = "2026-08-01"
+last_seen_line = 65
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for LLM abstraction"
+expires = "2026-08-01"
+last_seen_line = 78
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata field for LLM invocation tracking"
+expires = "2026-08-01"
+last_seen_line = 88
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata field for LLM invocation tracking"
+expires = "2026-08-01"
+last_seen_line = 91
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for LLM abstraction"
+expires = "2026-08-01"
+last_seen_line = 125
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/types.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for LLM abstraction"
+expires = "2026-08-01"
+last_seen_line = 197
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/budgeted_backend.rs"
+owner = "xchecker-maintainers"
+reason = "Deprecated but kept for backwards compatibility"
+expires = "2026-08-01"
+last_seen_line = 62
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-llm/src/gemini_cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 27
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-llm/src/gemini_cli.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 257
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 49
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 77
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 189
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 199
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 214
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 297
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-hooks/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for hooks integration; not wired in v1.0"
+expires = "2026-08-01"
+last_seen_line = 589
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for detailed redaction reporting"
+expires = "2026-08-01"
+last_seen_line = 409
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for structured reporting"
+expires = "2026-08-01"
+last_seen_line = 412
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for batch redaction"
+expires = "2026-08-01"
+last_seen_line = 584
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for optional fields"
+expires = "2026-08-01"
+last_seen_line = 598
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for custom pattern configuration"
+expires = "2026-08-01"
+last_seen_line = 605
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for pattern configuration"
+expires = "2026-08-01"
+last_seen_line = 618
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for pattern introspection"
+expires = "2026-08-01"
+last_seen_line = 760
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Extended API for pattern introspection"
+expires = "2026-08-01"
+last_seen_line = 772
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Duplicate of SecretRedactor method, candidate for removal"
+expires = "2026-08-01"
+last_seen_line = 831
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-redaction/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Duplicate of SecretRedactor method, candidate for removal"
+expires = "2026-08-01"
+last_seen_line = 844
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-workspace/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Test seam; not part of public API stability guarantees"
+expires = "2026-08-01"
+last_seen_line = 111
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-lock/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 858
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-lock/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Lock management utility"
+expires = "2026-08-01"
+last_seen_line = 886
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-lock/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 903
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-lock/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 910
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-lock/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Lock cleanup utility for CLI commands"
+expires = "2026-08-01"
+last_seen_line = 1225
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/exit_codes.rs"
+owner = "xchecker-maintainers"
+reason = "Used in tests (line 103)"
+expires = "2026-08-01"
+last_seen_line = 133
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/exit_codes.rs"
+owner = "xchecker-maintainers"
+reason = "Error handling utility for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 156
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used when CLI adds --verbose flag"
+expires = "2026-08-01"
+last_seen_line = 31
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging in orchestrator"
+expires = "2026-08-01"
+last_seen_line = 86
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging in orchestrator"
+expires = "2026-08-01"
+last_seen_line = 98
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging in orchestrator"
+expires = "2026-08-01"
+last_seen_line = 109
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging in orchestrator"
+expires = "2026-08-01"
+last_seen_line = 122
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for detailed operation logging"
+expires = "2026-08-01"
+last_seen_line = 167
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for performance tracking"
+expires = "2026-08-01"
+last_seen_line = 178
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for performance reporting"
+expires = "2026-08-01"
+last_seen_line = 187
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for memory profiling"
+expires = "2026-08-01"
+last_seen_line = 205
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for performance analysis"
+expires = "2026-08-01"
+last_seen_line = 217
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 302
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 308
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 314
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 321
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 328
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured logging context"
+expires = "2026-08-01"
+last_seen_line = 335
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose logging control"
+expires = "2026-08-01"
+last_seen_line = 342
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for formatted verbose logging"
+expires = "2026-08-01"
+last_seen_line = 385
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured info logging"
+expires = "2026-08-01"
+last_seen_line = 422
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured warning logging"
+expires = "2026-08-01"
+last_seen_line = 445
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for structured error logging"
+expires = "2026-08-01"
+last_seen_line = 469
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for file operation logging"
+expires = "2026-08-01"
+last_seen_line = 523
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose packet logging"
+expires = "2026-08-01"
+last_seen_line = 555
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose packet logging"
+expires = "2026-08-01"
+last_seen_line = 566
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose packet logging"
+expires = "2026-08-01"
+last_seen_line = 574
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose execution logging"
+expires = "2026-08-01"
+last_seen_line = 593
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose canonicalization logging"
+expires = "2026-08-01"
+last_seen_line = 604
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for verbose redaction logging"
+expires = "2026-08-01"
+last_seen_line = 621
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for performance reporting"
+expires = "2026-08-01"
+last_seen_line = 641
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for file operation reporting"
+expires = "2026-08-01"
+last_seen_line = 655
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/logging.rs"
+owner = "xchecker-maintainers"
+reason = "Diagnostic logging utility"
+expires = "2026-08-01"
+last_seen_line = 861
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/atomic_write.rs"
+owner = "xchecker-maintainers"
+reason = "Test utility for cross-platform testing"
+expires = "2026-08-01"
+last_seen_line = 242
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/source.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 12
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/source.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 22
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-utils/src/cache.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 224
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/cache.rs"
+owner = "xchecker-maintainers"
+reason = "Cache management utility"
+expires = "2026-08-01"
+last_seen_line = 573
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/cache.rs"
+owner = "xchecker-maintainers"
+reason = "Diagnostic logging utility"
+expires = "2026-08-01"
+last_seen_line = 592
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/canonicalization.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future content-addressed storage"
+expires = "2026-08-01"
+last_seen_line = 39
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/canonicalization.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future content-addressed storage"
+expires = "2026-08-01"
+last_seen_line = 41
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/canonicalization.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 80
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/ring_buffer.rs"
+owner = "xchecker-maintainers"
+reason = "Standard collection API method"
+expires = "2026-08-01"
+last_seen_line = 44
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/ring_buffer.rs"
+owner = "xchecker-maintainers"
+reason = "Standard collection API method"
+expires = "2026-08-01"
+last_seen_line = 51
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/lock.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 412
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/lock.rs"
+owner = "xchecker-maintainers"
+reason = "Lock management utility"
+expires = "2026-08-01"
+last_seen_line = 440
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/lock.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 457
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/lock.rs"
+owner = "xchecker-maintainers"
+reason = "Lock introspection utility"
+expires = "2026-08-01"
+last_seen_line = 464
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/lock.rs"
+owner = "xchecker-maintainers"
+reason = "Lock cleanup utility for CLI commands"
+expires = "2026-08-01"
+last_seen_line = 778
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "API method for runner construction"
+expires = "2026-08-01"
+last_seen_line = 67
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Internal API for future use; CLI only supports native/wsl"
+expires = "2026-08-01"
+last_seen_line = 90
+
+[[debt]]
+lint = "unused_mut"
+path = "crates/xchecker-utils/src/runner/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 135
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-utils/src/runner/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 141
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Truncation tracking metadata"
+expires = "2026-08-01"
+last_seen_line = 53
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Truncation tracking metadata"
+expires = "2026-08-01"
+last_seen_line = 56
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 59
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 62
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Runner utility method for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 72
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-utils/src/runner/claude/detect.rs"
+owner = "xchecker-maintainers"
+reason = "Runner introspection utility"
+expires = "2026-08-01"
+last_seen_line = 113
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-tui/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 38
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/ring_buffer.rs"
+owner = "xchecker-maintainers"
+reason = "Standard collection API method"
+expires = "2026-08-01"
+last_seen_line = 42
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/ring_buffer.rs"
+owner = "xchecker-maintainers"
+reason = "Standard collection API method"
+expires = "2026-08-01"
+last_seen_line = 49
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "API method for runner construction"
+expires = "2026-08-01"
+last_seen_line = 68
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Internal API for future use; CLI only supports native/wsl"
+expires = "2026-08-01"
+last_seen_line = 91
+
+[[debt]]
+lint = "unused_mut"
+path = "crates/xchecker-runner/src/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 136
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-runner/src/claude/exec.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 142
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Truncation tracking metadata"
+expires = "2026-08-01"
+last_seen_line = 53
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Truncation tracking metadata"
+expires = "2026-08-01"
+last_seen_line = 56
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 59
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Buffer management metadata"
+expires = "2026-08-01"
+last_seen_line = 62
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/types.rs"
+owner = "xchecker-maintainers"
+reason = "Runner utility method for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 72
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-runner/src/claude/detect.rs"
+owner = "xchecker-maintainers"
+reason = "Runner introspection utility"
+expires = "2026-08-01"
+last_seen_line = 113
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-prompt-template/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Public API for template introspection"
+expires = "2026-08-01"
+last_seen_line = 83
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-prompt-template/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Public API for template introspection"
+expires = "2026-08-01"
+last_seen_line = 94
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-phase-api/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for workflow completion signaling"
+expires = "2026-08-01"
+last_seen_line = 31
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-phase-api/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for cross-phase artifact references"
+expires = "2026-08-01"
+last_seen_line = 45
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-phase-api/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata fields reserved for receipts and diagnostics"
+expires = "2026-08-01"
+last_seen_line = 67
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-phase-api/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata reserved for structured receipts"
+expires = "2026-08-01"
+last_seen_line = 85
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-phase-api/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Trait interface for resumable phases"
+expires = "2026-08-01"
+last_seen_line = 103
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-receipt/src/emit.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 24
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-receipt/src/emit.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 75
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-receipt/src/writer.rs"
+owner = "xchecker-maintainers"
+reason = "Receipt utility for tracking atomic write retries"
+expires = "2026-08-01"
+last_seen_line = 137
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-receipt/src/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Error handling utility for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 65
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-receipt/src/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Error handling utility for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 136
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-receipt/src/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 137
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error display API"
+expires = "2026-08-01"
+last_seen_line = 29
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for error display"
+expires = "2026-08-01"
+last_seen_line = 47
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative output method"
+expires = "2026-08-01"
+last_seen_line = 119
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error reporting API"
+expires = "2026-08-01"
+last_seen_line = 146
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error reporting API"
+expires = "2026-08-01"
+last_seen_line = 159
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Error reporting utility"
+expires = "2026-08-01"
+last_seen_line = 167
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error reporting utility"
+expires = "2026-08-01"
+last_seen_line = 181
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error reporting utility"
+expires = "2026-08-01"
+last_seen_line = 201
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative error reporting utility"
+expires = "2026-08-01"
+last_seen_line = 208
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-error-reporter/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Error reporting utility"
+expires = "2026-08-01"
+last_seen_line = 216
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Legacy/test-only; follow-up spec (V19+) to delete once tests migrate"
+expires = "2026-08-01"
+last_seen_line = 44
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Legacy/test-only; follow-up spec (V19+) to delete once tests migrate"
+expires = "2026-08-01"
+last_seen_line = 119
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 137
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 146
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 155
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Legacy/test-only; will be removed in V19+"
+expires = "2026-08-01"
+last_seen_line = 221
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Legacy/test-only; follow-up spec (V19+) to delete once tests migrate"
+expires = "2026-08-01"
+last_seen_line = 232
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/claude.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 463
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-engine/src/receipt/emit.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 24
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-engine/src/receipt/emit.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 75
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/receipt/writer.rs"
+owner = "xchecker-maintainers"
+reason = "Receipt utility for tracking atomic write retries"
+expires = "2026-08-01"
+last_seen_line = 137
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/receipt/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Error handling utility for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 65
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/receipt/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Error handling utility for receipt generation"
+expires = "2026-08-01"
+last_seen_line = 136
+
+[[debt]]
+lint = "clippy::too_many_arguments"
+path = "crates/xchecker-engine/src/receipt/errors.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 137
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 12
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 15
+
+[[debt]]
+lint = "unused_imports"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 19
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 408
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 427
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Test helper: kept for future test expansion"
+expires = "2026-08-01"
+last_seen_line = 455
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Test helper: kept for future test expansion"
+expires = "2026-08-01"
+last_seen_line = 472
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Test helper: kept for future test expansion"
+expires = "2026-08-01"
+last_seen_line = 485
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for workflow execution API"
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for workflow execution API"
+expires = "2026-08-01"
+last_seen_line = 38
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for workflow execution API"
+expires = "2026-08-01"
+last_seen_line = 57
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for complete workflow execution"
+expires = "2026-08-01"
+last_seen_line = 78
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for phase execution with rewind"
+expires = "2026-08-01"
+last_seen_line = 208
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/workflow.rs"
+owner = "xchecker-maintainers"
+reason = "Future-facing: used for phase execution with next step handling"
+expires = "2026-08-01"
+last_seen_line = 280
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/phase_exec.rs"
+owner = "xchecker-maintainers"
+reason = "Phase execution method for CLI/library usage"
+expires = "2026-08-01"
+last_seen_line = 235
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/orchestrator/phase_exec.rs"
+owner = "xchecker-maintainers"
+reason = "Phase execution method for CLI/library usage"
+expires = "2026-08-01"
+last_seen_line = 260
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/fixup/apply.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 401
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/packet/selectors.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative API constructor"
+expires = "2026-08-01"
+last_seen_line = 127
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/packet/model.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata for budget tracking"
+expires = "2026-08-01"
+last_seen_line = 69
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-engine/src/packet/model.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata for budget tracking"
+expires = "2026-08-01"
+last_seen_line = 72
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/selectors.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative API constructor"
+expires = "2026-08-01"
+last_seen_line = 128
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/model.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata for budget tracking"
+expires = "2026-08-01"
+last_seen_line = 69
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/model.rs"
+owner = "xchecker-maintainers"
+reason = "Metadata for budget tracking"
+expires = "2026-08-01"
+last_seen_line = 72
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Public API for packet inspection"
+expires = "2026-08-01"
+last_seen_line = 47
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Public API for evidence inspection"
+expires = "2026-08-01"
+last_seen_line = 60
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Public API for budget validation"
+expires = "2026-08-01"
+last_seen_line = 73
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 52
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 88
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 104
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 116
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 133
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 150
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder pattern method for API surface"
+expires = "2026-08-01"
+last_seen_line = 168
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder accessor for API surface"
+expires = "2026-08-01"
+last_seen_line = 186
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder accessor for API surface"
+expires = "2026-08-01"
+last_seen_line = 193
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder accessor for API surface"
+expires = "2026-08-01"
+last_seen_line = 199
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder accessor for API surface"
+expires = "2026-08-01"
+last_seen_line = 206
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder setter for API surface"
+expires = "2026-08-01"
+last_seen_line = 212
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder method for API surface"
+expires = "2026-08-01"
+last_seen_line = 218
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Builder configuration method"
+expires = "2026-08-01"
+last_seen_line = 231
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-packet/src/builder.rs"
+owner = "xchecker-maintainers"
+reason = "Diagnostic logging utility"
+expires = "2026-08-01"
+last_seen_line = 433
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/status.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for orchestration APIs; not currently used by CLI"
+expires = "2026-08-01"
+last_seen_line = 26
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/status.rs"
+owner = "xchecker-maintainers"
+reason = "Alternative formatting option"
+expires = "2026-08-01"
+last_seen_line = 244
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/status.rs"
+owner = "xchecker-maintainers"
+reason = "Public wrapper retained for compatibility"
+expires = "2026-08-01"
+last_seen_line = 253
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Hash field for future content verification"
+expires = "2026-08-01"
+last_seen_line = 38
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "API constructor for artifact creation"
+expires = "2026-08-01"
+last_seen_line = 45
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for debugging artifacts"
+expires = "2026-08-01"
+last_seen_line = 77
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "API constructor for artifact manager"
+expires = "2026-08-01"
+last_seen_line = 99
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 327
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 344
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 452
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 477
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 492
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-status/src/artifact.rs"
+owner = "xchecker-maintainers"
+reason = "Test harness/utility method"
+expires = "2026-08-01"
+last_seen_line = 513
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-config/src/config/model.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 176
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-doctor/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "CLI integration point"
+expires = "2026-08-01"
+last_seen_line = 42
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-doctor/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "CLI integration point"
+expires = "2026-08-01"
+last_seen_line = 54
+
+[[debt]]
+lint = "dead_code"
+path = "crates/xchecker-benchmark/src/lib.rs"
+owner = "xchecker-maintainers"
+reason = "Performance data for receipts"
+expires = "2026-08-01"
+last_seen_line = 87
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/m1_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 31
+
+[[debt]]
+lint = "dead_code"
+path = "tests/m1_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 40
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_phase_timeout.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_phase_timeout.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 30
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_phase_timeout.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 32
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_phase_timeout.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 34
+
+[[debt]]
+lint = "clippy::duplicated_attributes"
+path = "tests/property_based_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 2
+
+[[debt]]
+lint = "dead_code"
+path = "tests/property_based_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 1155
+
+[[debt]]
+lint = "dead_code"
+path = "tests/property_based_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 1163
+
+[[debt]]
+lint = "clippy::await_holding_lock"
+path = "tests/test_hooks_integration.rs"
+owner = "xchecker-maintainers"
+reason = "Lock serializes tests; safe in single-threaded test context"
+expires = "2026-08-01"
+last_seen_line = 60
+
+[[debt]]
+lint = "clippy::await_holding_lock"
+path = "tests/test_hooks_integration.rs"
+owner = "xchecker-maintainers"
+reason = "Lock serializes tests; safe in single-threaded test context"
+expires = "2026-08-01"
+last_seen_line = 123
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_wsl_runner.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 6
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_wsl_runner.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 16
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_wsl_runner.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 19
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_phase_timeout_scenarios.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 22
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_phase_timeout_scenarios.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 31
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_phase_timeout_scenarios.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 33
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_llm_budget_exhaustion_receipt.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future integration tests"
+expires = "2026-08-01"
+last_seen_line = 25
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/integration_m1_gate.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 27
+
+[[debt]]
+lint = "dead_code"
+path = "tests/integration_m1_gate.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 36
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_lockfile_concurrent_execution.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 10
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/integration_full_workflows.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 25
+
+[[debt]]
+lint = "dead_code"
+path = "tests/integration_full_workflows.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 52
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_windows_job_objects.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 216
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/m3_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 27
+
+[[debt]]
+lint = "dead_code"
+path = "tests/m3_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 36
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_workflow_receipt_regression.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 18
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_workflow_receipt_regression.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 27
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_workflow_receipt_regression.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 29
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 28
+
+[[debt]]
+lint = "dead_code"
+path = "tests/m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 37
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/m1_gate_simple.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/m1_gate_simple_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 21
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/security_path_traversal.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 8
+
+[[debt]]
+lint = "dead_code"
+path = "tests/security_path_traversal.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 17
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 107
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 161
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 228
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 285
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 389
+
+[[debt]]
+lint = "unused_imports"
+path = "tests/test_unix_process_termination.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 452
+
+[[debt]]
+lint = "clippy::permissions_set_readonly_false"
+path = "tests/test_fixup_apply_mode.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 490
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/test_m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 23
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 32
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 34
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 36
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_m4_gate_validation.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 38
+
+[[debt]]
+lint = "unused_mut"
+path = "tests/command_injection_tests.rs"
+owner = "xchecker-maintainers"
+reason = "mut needed on Unix for .output().await"
+expires = "2026-08-01"
+last_seen_line = 79
+
+[[debt]]
+lint = "clippy::duplicated_attributes"
+path = "tests/golden_pipeline_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 2
+
+[[debt]]
+lint = "clippy::duplicate_mod"
+path = "tests/golden_pipeline_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 25
+
+[[debt]]
+lint = "dead_code"
+path = "tests/golden_pipeline_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 34
+
+[[debt]]
+lint = "dead_code"
+path = "tests/test_support/mod.rs"
+owner = "xchecker-maintainers"
+reason = "Existing suppression captured as temporary lint-policy debt during strict baseline rollout."
+expires = "2026-08-01"
+last_seen_line = 5
+
+[[debt]]
+lint = "dead_code"
+path = "tests/doc_validation/code_examples_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Retained for parity with jq flags"
+expires = "2026-08-01"
+last_seen_line = 672
+
+[[debt]]
+lint = "dead_code"
+path = "tests/doc_validation/common.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 222
+
+[[debt]]
+lint = "dead_code"
+path = "tests/doc_validation/changelog_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 135
+
+[[debt]]
+lint = "dead_code"
+path = "tests/doc_validation/changelog_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 254
+
+[[debt]]
+lint = "dead_code"
+path = "tests/doc_validation/changelog_tests.rs"
+owner = "xchecker-maintainers"
+reason = "Reserved for future test cases"
+expires = "2026-08-01"
+last_seen_line = 387

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,799 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active Rust lint baseline.
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe-memory"
+reason = "xchecker must not introduce unsafe Rust into orchestration, receipt, runner, or provider code."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "If unsafe is ever introduced under a narrow exception, operations must remain explicit and reviewable."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Results, futures, locks, and process outcomes must not be silently dropped."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "configuration"
+reason = "Keep feature and platform cfg spellings visible during review."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid shared mutable constants that can create surprising global state."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid pointer/int confusion at FFI and process-boundary seams."
+
+# Active Clippy lint baseline. Keep these entries aligned with [workspace.lints.clippy].
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked panic-family control flow in production or tests."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Avoid UTF-8, slice, and parser-boundary footguns."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Avoid UTF-8, slice, and parser-boundary footguns."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "parser-safety"
+reason = "Avoid UTF-8, slice, and parser-boundary footguns."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "No swallowed work, ignored errors, or dropped futures."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Keep async and lock behavior reviewable and deadlock-resistant."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep memory-safety-sensitive patterns explicit and reviewed."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric-correctness"
+reason = "Surface numeric precision, cast, and arithmetic risks."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Avoid filesystem, path, and process-boundary footguns."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-correctness"
+reason = "Keep public API and trait contracts precise."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer clearer control-flow, formatting, and allocation shapes."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Suppressions must be explicit, narrow, and justified."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Suppressions must be explicit, narrow, and justified."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Suppressions must be explicit, narrow, and justified."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Suppressions must be explicit, narrow, and justified."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Suppressions must be explicit, narrow, and justified."
+
+# Planned Rust-version flips. These are intentionally not active at MSRV 1.93.
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric-correctness"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric-correctness"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,6 @@
+schema_version = "0.3"
+
+# Semantic no-panic allowlist entries live here when a panic-family call cannot
+# be removed immediately. Identity is path + family + selector; last_seen is
+# advisory only. This initial policy PR establishes the schema and leaves the
+# large no-panic migration for follow-up cleanup PRs.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "docs/**"
+kind = "documentation"
+owner = "docs"
+reason = "Project documentation is authored in Markdown and schema files."
+surface = "docs"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "schemas/**"
+kind = "json_schema"
+owner = "contracts"
+reason = "JSON schemas are the published machine-readable contracts."
+surface = "contracts"
+classification = "config"
+covered_by = ["cargo test --features dev-tools --test doc_validation -- --test-threads=1"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,370 @@
+use std::{collections::BTreeMap, env, fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use chrono::NaiveDate;
+use serde::Deserialize;
+use toml::Value;
+
+const FORBIDDEN_TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct ClippyPolicyFile {
+    schema: u32,
+    msrv: String,
+    policy: PolicyHeader,
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyHeader {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    class: String,
+    reason: String,
+    activate_when_msrv: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtFile {
+    schema: u32,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+fn main() -> Result<()> {
+    match env::args().nth(1).as_deref() {
+        Some("check-lint-policy") => check_lint_policy(),
+        Some("help") | None => {
+            println!("usage: cargo xtask check-lint-policy");
+            Ok(())
+        }
+        Some(command) => bail!("unknown xtask command `{command}`; try `cargo xtask help`"),
+    }
+}
+
+fn check_lint_policy() -> Result<()> {
+    let mut errors = Vec::new();
+
+    let cargo = read_toml("Cargo.toml")?;
+    let policy: ClippyPolicyFile = read_toml_as("policy/clippy-lints.toml")?;
+    let debt: DebtFile = read_toml_as("policy/clippy-debt.toml")?;
+
+    if policy.schema != 1 {
+        errors.push(format!(
+            "policy/clippy-lints.toml schema must be 1, got {}",
+            policy.schema
+        ));
+    }
+    if debt.schema != 1 {
+        errors.push(format!(
+            "policy/clippy-debt.toml schema must be 1, got {}",
+            debt.schema
+        ));
+    }
+
+    check_policy_header(&policy, &mut errors);
+    check_msrv(&cargo, &policy, &mut errors);
+    check_workspace_lints(&cargo, &policy, &mut errors);
+    check_lint_inheritance(&cargo, &mut errors)?;
+    check_clippy_toml(&mut errors)?;
+    check_debt(&debt, &mut errors);
+
+    if errors.is_empty() {
+        println!("lint policy check passed");
+        Ok(())
+    } else {
+        for error in &errors {
+            eprintln!("lint policy error: {error}");
+        }
+        bail!("lint policy check failed with {} error(s)", errors.len())
+    }
+}
+
+fn check_policy_header(policy: &ClippyPolicyFile, errors: &mut Vec<String>) {
+    if !policy.policy.panic_free_tests {
+        errors.push("policy.panic_free_tests must be true".to_string());
+    }
+    if policy.policy.allow_test_carveouts {
+        errors.push("policy.allow_test_carveouts must be false".to_string());
+    }
+    if policy.policy.suppression_style != "expect-with-reason" {
+        errors.push("policy.suppression_style must be `expect-with-reason`".to_string());
+    }
+    if policy.policy.blanket_categories {
+        errors.push("policy.blanket_categories must be false".to_string());
+    }
+}
+
+fn check_msrv(cargo: &Value, policy: &ClippyPolicyFile, errors: &mut Vec<String>) {
+    let workspace_msrv = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str);
+    if workspace_msrv != Some(policy.msrv.as_str()) {
+        errors.push(format!(
+            "workspace.package.rust-version must equal policy msrv {}; got {:?}",
+            policy.msrv, workspace_msrv
+        ));
+    }
+
+    let root_msrv = cargo
+        .get("package")
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str);
+    if root_msrv != Some(policy.msrv.as_str()) {
+        errors.push(format!(
+            "root package rust-version must equal policy msrv {}; got {:?}",
+            policy.msrv, root_msrv
+        ));
+    }
+}
+
+fn check_workspace_lints(cargo: &Value, policy: &ClippyPolicyFile, errors: &mut Vec<String>) {
+    let rust_lints = table_at(cargo, &["workspace", "lints", "rust"]);
+    let clippy_lints = table_at(cargo, &["workspace", "lints", "clippy"]);
+    let mut active_seen = BTreeMap::new();
+
+    for lint in &policy.lint {
+        if lint.name.trim().is_empty()
+            || lint.class.trim().is_empty()
+            || lint.reason.trim().is_empty()
+        {
+            errors.push(format!(
+                "lint {} must include name, class, and reason",
+                lint.name
+            ));
+        }
+        match lint.status.as_str() {
+            "active" => {
+                let (namespace, name) = split_lint_name(&lint.name, errors);
+                let actual = match namespace {
+                    Some("rust") => {
+                        rust_lints.and_then(|table| table.get(name.unwrap_or_default()))
+                    }
+                    Some("clippy") => {
+                        clippy_lints.and_then(|table| table.get(name.unwrap_or_default()))
+                    }
+                    _ => None,
+                }
+                .and_then(Value::as_str);
+                if actual != Some(lint.level.as_str()) {
+                    errors.push(format!(
+                        "active lint {} must be {} in Cargo.toml, got {:?}",
+                        lint.name, lint.level, actual
+                    ));
+                }
+                active_seen.insert(lint.name.clone(), lint.level.clone());
+                if lint.activate_when_msrv.is_some() {
+                    errors.push(format!(
+                        "active lint {} must not set activate_when_msrv",
+                        lint.name
+                    ));
+                }
+            }
+            "planned" => {
+                if lint.activate_when_msrv.as_deref().is_none_or(str::is_empty) {
+                    errors.push(format!(
+                        "planned lint {} must set activate_when_msrv",
+                        lint.name
+                    ));
+                }
+                let (_, name) = split_lint_name(&lint.name, errors);
+                if let Some(name) = name
+                    && (rust_lints.is_some_and(|table| table.contains_key(name))
+                        || clippy_lints.is_some_and(|table| table.contains_key(name)))
+                {
+                    errors.push(format!(
+                        "planned lint {} must not be active before its MSRV flip",
+                        lint.name
+                    ));
+                }
+            }
+            other => errors.push(format!("lint {} has unknown status `{other}`", lint.name)),
+        }
+    }
+
+    if let Some(table) = rust_lints {
+        for (name, value) in table {
+            let full_name = format!("rust::{name}");
+            if !active_seen.contains_key(&full_name) {
+                errors.push(format!(
+                    "Cargo.toml rust lint {full_name} is missing from policy ledger"
+                ));
+            }
+            if !value.is_str() {
+                errors.push(format!(
+                    "Cargo.toml rust lint {full_name} must use string level"
+                ));
+            }
+        }
+    } else {
+        errors.push("Cargo.toml missing [workspace.lints.rust]".to_string());
+    }
+
+    if let Some(table) = clippy_lints {
+        for (name, value) in table {
+            let full_name = format!("clippy::{name}");
+            if !active_seen.contains_key(&full_name) {
+                errors.push(format!(
+                    "Cargo.toml clippy lint {full_name} is missing from policy ledger"
+                ));
+            }
+            if !value.is_str() {
+                errors.push(format!(
+                    "Cargo.toml clippy lint {full_name} must use string level"
+                ));
+            }
+        }
+    } else {
+        errors.push("Cargo.toml missing [workspace.lints.clippy]".to_string());
+    }
+}
+
+fn check_lint_inheritance(cargo: &Value, errors: &mut Vec<String>) -> Result<()> {
+    check_one_lints_table("Cargo.toml", cargo, errors);
+    let members = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(Value::as_array)
+        .context("workspace.members must be an array")?;
+
+    for member in members {
+        let Some(member) = member.as_str() else {
+            continue;
+        };
+        if member == "." {
+            continue;
+        }
+        let manifest = Path::new(member).join("Cargo.toml");
+        let manifest_value = read_toml(&manifest)?;
+        check_one_lints_table(&manifest.display().to_string(), &manifest_value, errors);
+    }
+    Ok(())
+}
+
+fn check_one_lints_table(path: &str, cargo: &Value, errors: &mut Vec<String>) {
+    let inherits = cargo
+        .get("lints")
+        .and_then(|lints| lints.get("workspace"))
+        .and_then(Value::as_bool);
+    if inherits != Some(true) {
+        errors.push(format!("{path} must contain [lints] workspace = true"));
+    }
+}
+
+fn check_clippy_toml(errors: &mut Vec<String>) -> Result<()> {
+    let path = Path::new("clippy.toml");
+    if !path.exists() {
+        errors.push("clippy.toml must exist".to_string());
+        return Ok(());
+    }
+    let content = fs::read_to_string(path).context("read clippy.toml")?;
+    for carveout in FORBIDDEN_TEST_CARVEOUTS {
+        if content.contains(carveout)
+            && content.lines().any(|line| {
+                let trimmed = line.trim_start();
+                trimmed.starts_with(carveout) && trimmed.contains("true")
+            })
+        {
+            errors.push(format!("clippy.toml must not enable {carveout}"));
+        }
+    }
+    Ok(())
+}
+
+fn check_debt(debt: &DebtFile, errors: &mut Vec<String>) {
+    let today = chrono::Utc::now().date_naive();
+    for entry in &debt.debt {
+        if entry.lint.trim().is_empty() {
+            errors.push(format!("debt entry for {} has empty lint", entry.path));
+        }
+        if entry.path.trim().is_empty() {
+            errors.push(format!("debt entry for {} has empty path", entry.lint));
+        }
+        if entry.owner.trim().is_empty() {
+            errors.push(format!(
+                "debt entry for {} in {} has empty owner",
+                entry.lint, entry.path
+            ));
+        }
+        if entry.reason.trim().is_empty() {
+            errors.push(format!(
+                "debt entry for {} in {} has empty reason",
+                entry.lint, entry.path
+            ));
+        }
+        match NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d") {
+            Ok(expires) if expires < today => errors.push(format!(
+                "debt entry for {} in {} expired on {}",
+                entry.lint, entry.path, entry.expires
+            )),
+            Ok(_) => {}
+            Err(error) => errors.push(format!(
+                "debt entry for {} in {} has invalid expiry {}: {error}",
+                entry.lint, entry.path, entry.expires
+            )),
+        }
+    }
+}
+
+fn split_lint_name<'a>(
+    name: &'a str,
+    errors: &mut Vec<String>,
+) -> (Option<&'a str>, Option<&'a str>) {
+    match name.split_once("::") {
+        Some((namespace @ ("rust" | "clippy"), lint)) if !lint.is_empty() => {
+            (Some(namespace), Some(lint))
+        }
+        _ => {
+            errors.push(format!(
+                "lint name {name} must be rust::name or clippy::name"
+            ));
+            (None, None)
+        }
+    }
+}
+
+fn table_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a toml::map::Map<String, Value>> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_table()
+}
+
+fn read_toml(path: impl AsRef<Path>) -> Result<Value> {
+    let path = path.as_ref();
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("parse {}", path.display()))
+}
+
+fn read_toml_as<T: for<'de> Deserialize<'de>>(path: impl AsRef<Path>) -> Result<T> {
+    let path = path.as_ref();
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("parse {}", path.display()))
+}


### PR DESCRIPTION
### Motivation
- Establish a governed, machine-readable Clippy policy (panic-free, no silent failures, suppression governance) as a workspace infrastructure instead of per-repo taste blocks.
- Converge Rust workspaces to a common MSRV and lint surface (MSRV = `1.93`) so planned flips for `1.94`/`1.95` can be tracked and gated.
- Provide an automated xtask gate to validate MSRV/lint inheritance, forbid test carveouts, and ensure debt entries are explicit and expiring. 
- Introduce structured TOML allowlists for no-panic and non-Rust surfaces so exceptions are reviewable and machine-checkable.

### Description
- Bumped workspace and root package `rust-version` to `1.93` and added a shared workspace lint baseline under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in `Cargo.toml`.
- Added `[lints] workspace = true` to workspace member manifests and wired a workspace `cargo xtask` alias in `.cargo/config.toml`.
- Added repo-local `clippy.toml` (explicitly no test carveouts) and `docs/CLIPPY_POLICY.md` documenting the policy, suppression style, and rollout model.
- Added a new `xtask` crate with `cargo xtask check-lint-policy` that validates MSRV alignment, active/planned lint ledger consistency, workspace lint inheritance, forbidden clippy test carveouts, and debt metadata/expiry.
- Introduced machine-readable policy artifacts under `policy/`: `clippy-lints.toml` (active + planned lints ledger), `clippy-debt.toml` (captured existing suppressions as temporary debt entries), `no-panic-allowlist.toml` (semantic no-panic schema), and `non-rust-allowlist.toml` (non-Rust surface allowlist).
- Performed formatting adjustments (`cargo fmt`) and minor source tidy-ups required by the new baseline and to keep the xtask code clean; left rollout debt in `policy/clippy-debt.toml` instead of weakening the baseline.

### Testing
- Ran `cargo xtask check-lint-policy` and it passed against the new machine-readable ledgers and workspace configuration. (passed)
- Built and checked the xtask gate with `cargo check -p xtask` and ran `cargo clippy -p xtask -- -D warnings` to validate xtask code quality. (passed)
- Ran `cargo fmt -- --check` after installing `rustfmt` to ensure formatting is stable. (passed)
- Ran full workspace linting with `cargo clippy --workspace --all-targets --all-features -- -D warnings`, which currently fails on pre-existing rollout debt (intentional), surfacing existing `#[allow(...)]` suppressions, unsafe blocks, panic-family calls, missing errors docs, and silent-failure lints in crates such as `xchecker-lock` and `xchecker-runner`; these are captured as explicit, expiring debt to be remediated in follow-up stacked PRs. (expected failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0a0292ec8333a89d55e24c9111c8)