### PR TITLE
Refactor phase execution into SRP helper submodules

### DIFF
--- a/crates/xchecker-engine/src/orchestrator/phase_exec.rs
+++ b/crates/xchecker-engine/src/orchestrator/phase_exec.rs
@@ -10,15 +10,25 @@ use anyhow::{Context, Result};
 use crate::error::{PhaseError, XCheckerError};
 use crate::exit_codes;
 use crate::fixup::{FixupMode, FixupPhase};
-use crate::hooks::{HookContext, HookExecutor, HookType, execute_and_process_hook};
-use crate::packet::PacketBuilder;
 use crate::phase::{Phase, PhaseContext};
 use crate::phases::{DesignPhase, RequirementsPhase, ReviewPhase, TasksPhase};
 use crate::status::artifact::{Artifact, ArtifactType};
-use crate::types::{ErrorKind, FileType, LlmInfo, PacketEvidence, PhaseId, PipelineInfo};
+use crate::types::{ErrorKind, PacketEvidence, PhaseId, PipelineInfo};
 
-use super::llm::{ClaudeExecutionMetadata, LlmInvocationError};
+use super::llm::ClaudeExecutionMetadata;
 use super::{OrchestratorConfig, PhaseOrchestrator, PhaseTimeout};
+
+#[path = "phase_exec/artifacts.rs"]
+mod artifacts;
+#[path = "phase_exec/hooks.rs"]
+mod hooks;
+#[path = "phase_exec/llm.rs"]
+mod llm;
+#[path = "phase_exec/packet.rs"]
+mod packet;
+
+use hooks::PrePhaseHookResult;
+use llm::PhaseLlmOutcome;
 
 /// Result of executing a phase through the orchestrator.
 ///
@@ -502,26 +512,7 @@ impl PhaseOrchestrator {
         let prompt = phase.prompt(&phase_context);
 
         // Step 2: Build packet (FR-ORC-003)
-        let packet = phase.make_packet(&phase_context).map_err(|e| {
-            XCheckerError::Phase(PhaseError::PacketCreationFailed {
-                phase: phase_id.as_str().to_string(),
-                reason: e.to_string(),
-            })
-        })?;
-
-        // Log packet hash and budget usage for visibility
-        let budget = packet.budget_usage();
-        tracing::info!(
-            target: "xchecker::packet",
-            spec_id = %self.spec_id(),
-            phase = %phase_id.as_str(),
-            packet_hash = %packet.hash(),
-            bytes_used = budget.bytes_used,
-            bytes_limit = budget.max_bytes,
-            lines_used = budget.lines_used,
-            lines_limit = budget.max_lines,
-            "Built packet for phase"
-        );
+        let packet = self.build_phase_packet(phase, &phase_context, phase_id)?;
 
         let packet_evidence = packet.evidence.clone();
 
@@ -537,37 +528,8 @@ impl PhaseOrchestrator {
             .into());
         }
 
-        // Store packet for debugging/preview
-        let _packet_preview_path = self
-            .artifact_manager()
-            .store_context_file(&format!("{}-packet", phase_id.as_str()), &packet.content)?;
-
-        // Step 4: Write full debug packet if --debug-packet flag is set (FR-PKT-006, FR-PKT-007)
-        // Only write after secret scan passes; file is excluded from receipts
-        let debug_packet_enabled = config
-            .config
-            .get("debug_packet")
-            .is_some_and(|s| s == "true");
-
-        if debug_packet_enabled {
-            // Get context directory from artifact manager
-            let context_dir = self.artifact_manager().context_path();
-
-            // Create a temporary PacketBuilder just to call write_debug_packet
-            let temp_builder = PacketBuilder::new().map_err(|e| {
-                XCheckerError::Phase(PhaseError::PacketCreationFailed {
-                    phase: phase_id.as_str().to_string(),
-                    reason: format!("Failed to create PacketBuilder for debug packet: {e}"),
-                })
-            })?;
-
-            if let Err(e) =
-                temp_builder.write_debug_packet(&packet.content, phase_id.as_str(), &context_dir)
-            {
-                // Log warning but don't fail the operation (debug packet is optional)
-                eprintln!("Warning: Failed to write debug packet: {e}");
-            }
-        }
+        // Store packet for debugging/preview after secret scan passes.
+        self.persist_packet_context(phase_id, &packet.content, config)?;
 
         // Step 5: Execute LLM (or simulate in dry-run mode)
         let (claude_response, claude_exit_code, claude_metadata, llm_result, llm_fallback_warning) =
@@ -614,24 +576,8 @@ impl PhaseOrchestrator {
             }
         };
 
-        // Step 7: Write partial artifacts to .partial/ subdirectory (FR-ORC-004)
-        for artifact in &phase_result.artifacts {
-            // Store to .partial/ staging directory first
-            let _partial_result = self
-                .artifact_manager()
-                .store_partial_staged_artifact(artifact)
-                .with_context(|| format!("Failed to store partial artifact: {}", artifact.name))?;
-        }
-
-        // Step 8: Promote to final (atomic rename) (FR-ORC-004)
-        for artifact in &phase_result.artifacts {
-            let _final_path = self
-                .artifact_manager()
-                .promote_staged_to_final(&artifact.name)
-                .with_context(|| {
-                    format!("Failed to promote artifact to final: {}", artifact.name)
-                })?;
-        }
+        // Steps 7-8: Stage artifacts, then promote them to final paths (FR-ORC-004).
+        self.store_core_phase_artifacts(&phase_result.artifacts)?;
 
         // Return intermediate values for receipt generation
         // Note: Callers (workflow.rs) re-store artifacts and re-compute hashes,
@@ -671,175 +617,19 @@ impl PhaseOrchestrator {
         // Check dependencies (Requirements phase has no deps)
         self.check_phase_dependencies(phase)?;
 
-        // Execute pre-phase hook if configured
-        // Hooks run from invocation CWD so relative paths like ./scripts/... work
-        let mut hook_warnings: Vec<String> = Vec::new();
-        if let Some(ref hooks_config) = config.hooks
-            && let Some(hook_config) = hooks_config.get_pre_phase_hook(phase_id)
+        let hook_warnings = match self
+            .run_pre_phase_hook(phase_id, config, pipeline_info.clone())
+            .await?
         {
-            let executor = HookExecutor::new(
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-            );
-            let context = HookContext::new(self.spec_id(), phase_id, HookType::PrePhase);
-
-            match execute_and_process_hook(
-                &executor,
-                hook_config,
-                &context,
-                HookType::PrePhase,
-                phase_id,
-            )
-            .await
-            {
-                Ok(outcome) => {
-                    if let Some(warning) = outcome.warning() {
-                        hook_warnings.push(warning.to_warning_string());
-                    }
-                    if !outcome.should_continue() {
-                        // Pre-hook failed with on_fail=fail - abort phase but still create receipt
-                        let error_reason = format!(
-                            "Pre-phase hook failed: {}",
-                            outcome.error().map(|e| e.to_string()).unwrap_or_default()
-                        );
-
-                        // Create failure receipt for hook failure (audit trail requirement)
-                        let packet_evidence = PacketEvidence {
-                            files: vec![],
-                            max_bytes: 65536,
-                            max_lines: 1200,
-                        };
-                        let mut flags = HashMap::new();
-                        flags.insert("phase".to_string(), phase_id.as_str().to_string());
-                        flags.insert("hook_failure".to_string(), "pre_phase".to_string());
-
-                        // Use config values for truthful failure receipts (no hard-coded metadata)
-                        let configured_model =
-                            config.config.get("model").map_or("unknown", |s| s.as_str());
-                        let configured_runner = config
-                            .config
-                            .get("runner_mode")
-                            .map_or("unknown", |s| s.as_str());
-
-                        let receipt = self.receipt_manager().create_receipt_with_redactor(
-                            config.redactor.as_ref(),
-                            self.spec_id(),
-                            phase_id,
-                            exit_codes::codes::CLAUDE_FAILURE,
-                            vec![], // No outputs
-                            env!("CARGO_PKG_VERSION"),
-                            "unknown", // Claude hasn't run yet, so version is unknown
-                            configured_model,
-                            None,
-                            flags,
-                            packet_evidence,
-                            None,
-                            None,
-                            hook_warnings.clone(),
-                            None,
-                            configured_runner,
-                            None,
-                            Some(ErrorKind::ClaudeFailure),
-                            Some(error_reason.clone()),
-                            None,
-                            pipeline_info.clone(),
-                        );
-
-                        let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
-
-                        return Ok(ExecutionResult {
-                            phase: phase_id,
-                            success: false,
-                            exit_code: exit_codes::codes::CLAUDE_FAILURE,
-                            artifact_paths: vec![],
-                            receipt_path: Some(receipt_path.into_std_path_buf()),
-                            error: Some(error_reason),
-                        });
-                    }
-                }
-                Err(e) => {
-                    // Hook execution error - treat as failure but still create receipt
-                    let error_reason = format!("Pre-phase hook error: {}", e);
-
-                    // Create failure receipt for hook error (audit trail requirement)
-                    let packet_evidence = PacketEvidence {
-                        files: vec![],
-                        max_bytes: 65536,
-                        max_lines: 1200,
-                    };
-                    let mut flags = HashMap::new();
-                    flags.insert("phase".to_string(), phase_id.as_str().to_string());
-                    flags.insert("hook_error".to_string(), "pre_phase".to_string());
-
-                    // Use config values for truthful failure receipts (no hard-coded metadata)
-                    let configured_model =
-                        config.config.get("model").map_or("unknown", |s| s.as_str());
-                    let configured_runner = config
-                        .config
-                        .get("runner_mode")
-                        .map_or("unknown", |s| s.as_str());
-
-                    let receipt = self.receipt_manager().create_receipt_with_redactor(
-                        config.redactor.as_ref(),
-                        self.spec_id(),
-                        phase_id,
-                        exit_codes::codes::CLAUDE_FAILURE,
-                        vec![], // No outputs
-                        env!("CARGO_PKG_VERSION"),
-                        "unknown", // Claude hasn't run yet, so version is unknown
-                        configured_model,
-                        None,
-                        flags,
-                        packet_evidence,
-                        None,
-                        None,
-                        vec![format!("hook_error:pre_phase:{}", e)],
-                        None,
-                        configured_runner,
-                        None,
-                        Some(ErrorKind::ClaudeFailure),
-                        Some(error_reason.clone()),
-                        None,
-                        pipeline_info.clone(),
-                    );
-
-                    let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
-
-                    return Ok(ExecutionResult {
-                        phase: phase_id,
-                        success: false,
-                        exit_code: exit_codes::codes::CLAUDE_FAILURE,
-                        artifact_paths: vec![],
-                        receipt_path: Some(receipt_path.into_std_path_buf()),
-                        error: Some(error_reason),
-                    });
-                }
-            }
-        }
+            PrePhaseHookResult::Continue { warnings } => warnings,
+            PrePhaseHookResult::Abort(result) => return Ok(result),
+        };
 
         // Generate prompt
         let prompt = phase.prompt(&phase_context);
 
         // Step 3: Build packet (FR-ORC-003)
-        let packet = phase.make_packet(&phase_context).map_err(|e| {
-            XCheckerError::Phase(PhaseError::PacketCreationFailed {
-                phase: phase_id.as_str().to_string(),
-                reason: e.to_string(),
-            })
-        })?;
-
-        // Log packet hash and budget usage for visibility
-        let budget = packet.budget_usage();
-        tracing::info!(
-            target: "xchecker::packet",
-            spec_id = %self.spec_id(),
-            phase = %phase_id.as_str(),
-            packet_hash = %packet.hash(),
-            bytes_used = budget.bytes_used,
-            bytes_limit = budget.max_bytes,
-            lines_used = budget.lines_used,
-            lines_limit = budget.max_lines,
-            "Built packet for phase"
-        );
+        let packet = self.build_phase_packet(phase, &phase_context, phase_id)?;
 
         // Step 4: Scan for secrets (FR-ORC-003, FR-SEC)
         let redactor = config.redactor.as_ref();
@@ -896,257 +686,36 @@ impl PhaseOrchestrator {
             });
         }
 
-        // Store packet for debugging/preview
-        let _packet_preview_path = self
-            .artifact_manager()
-            .store_context_file(&format!("{}-packet", phase_id.as_str()), &packet.content)?;
+        // Store packet for debugging/preview after secret scan passes.
+        self.persist_packet_context(phase_id, &packet.content, config)?;
 
-        // Write full debug packet if --debug-packet flag is set (FR-PKT-006, FR-PKT-007)
-        // Only write after secret scan passes; file is excluded from receipts
-        let debug_packet_enabled = config
-            .config
-            .get("debug_packet")
-            .is_some_and(|s| s == "true");
-
-        if debug_packet_enabled {
-            // Get context directory from artifact manager
-            let context_dir = self.artifact_manager().context_path();
-
-            // Create a temporary PacketBuilder just to call write_debug_packet
-            // (This is a bit awkward but maintains the existing API)
-            let temp_builder = PacketBuilder::new().map_err(|e| {
-                XCheckerError::Phase(PhaseError::PacketCreationFailed {
-                    phase: phase_id.as_str().to_string(),
-                    reason: format!("Failed to create PacketBuilder for debug packet: {e}"),
-                })
-            })?;
-
-            if let Err(e) =
-                temp_builder.write_debug_packet(&packet.content, phase_id.as_str(), &context_dir)
-            {
-                // Log warning but don't fail the operation (debug packet is optional)
-                eprintln!("Warning: Failed to write debug packet: {e}");
-            }
-        }
-
-        // Execute LLM (or simulate in dry-run mode)
-        let mut llm_fallback_warning: Option<String> = None;
-        let (claude_response, claude_exit_code, claude_metadata, llm_result) = if config.dry_run {
-            let simulated_llm = self.simulate_llm_result(phase_id);
-            let simulated_metadata = super::llm::ClaudeExecutionMetadata {
-                model_alias: None,
-                model_full_name: "haiku".to_string(),
-                claude_cli_version: "0.8.1".to_string(),
-                fallback_used: false,
-                runner: "simulated".to_string(),
-                runner_distro: None,
-                stderr_tail: None,
-            };
-            (
-                self.simulate_claude_response(phase_id, &prompt),
-                0,
-                Some(simulated_metadata),
-                Some(simulated_llm),
-            )
-        } else {
-            // Use new LLM backend abstraction (V11: Claude CLI only)
+        // Execute LLM (or simulate in dry-run mode) and convert invocation errors to receipts.
+        let (claude_response, claude_exit_code, claude_metadata, llm_result, llm_fallback_warning) =
             match self
-                .run_llm_invocation(&prompt, &packet.content, phase_id, config)
-                .await
+                .execute_llm_for_phase(phase_id, &prompt, &packet, config, pipeline_info.clone())
+                .await?
             {
-                Ok((response, exit_code, metadata, result, fallback_warning)) => {
-                    llm_fallback_warning = fallback_warning;
-                    (response, exit_code, metadata, result)
-                }
-                Err(e) => {
-                    let (xchecker_err, fallback_warning) =
-                        if let Some(invocation_err) = e.downcast_ref::<LlmInvocationError>() {
-                            (
-                                invocation_err.error(),
-                                invocation_err.fallback_warning().map(|s| s.to_string()),
-                            )
-                        } else if let Some(xchecker_err) = e.downcast_ref::<XCheckerError>() {
-                            (xchecker_err, None)
-                        } else {
-                            return Err(e);
-                        };
-
-                    llm_fallback_warning = fallback_warning;
-
-                    // Check if this is a budget exhaustion error by downcasting
-                    if let XCheckerError::Llm(llm_err) = xchecker_err {
-                        if matches!(llm_err, crate::llm::LlmError::BudgetExceeded { .. }) {
-                            // Handle budget exhaustion specially - create receipt with budget_exhausted flag
-                            let packet_evidence = packet.evidence.clone();
-                            let mut flags = HashMap::new();
-                            flags.insert("phase".to_string(), phase_id.as_str().to_string());
-
-                            // Use config values for truthful failure receipts (no hard-coded metadata)
-                            let configured_model =
-                                config.config.get("model").map_or("unknown", |s| s.as_str());
-                            let configured_runner = config
-                                .config
-                                .get("runner_mode")
-                                .map_or("unknown", |s| s.as_str());
-
-                            let mut warnings = vec![format!("LLM budget exhausted: {}", llm_err)];
-                            if let Some(ref warning) = llm_fallback_warning {
-                                warnings.push(warning.clone());
-                            }
-
-                            let mut receipt = self.receipt_manager().create_receipt_with_redactor(
-                                config.redactor.as_ref(),
-                                self.spec_id(),
-                                phase_id,
-                                exit_codes::codes::CLAUDE_FAILURE, // Exit code 70
-                                vec![],                            // No successful outputs
-                                env!("CARGO_PKG_VERSION"),
-                                "unknown", // Claude hasn't completed, so version is unknown
-                                configured_model,
-                                None, // No model alias
-                                flags,
-                                packet_evidence,
-                                None, // No stderr_tail
-                                None, // No stderr_redacted
-                                warnings,
-                                None, // No fallback
-                                configured_runner,
-                                None, // No runner distro
-                                Some(ErrorKind::ClaudeFailure),
-                                Some(llm_err.to_string()),
-                                None, // No diff_context
-                                pipeline_info.clone(),
-                            );
-
-                            // Attach LlmInfo with budget_exhausted flag
-                            receipt.llm = Some(LlmInfo::for_budget_exhaustion());
-
-                            let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
-
-                            return Ok(ExecutionResult {
-                                phase: phase_id,
-                                success: false,
-                                exit_code: exit_codes::codes::CLAUDE_FAILURE,
-                                artifact_paths: vec![],
-                                receipt_path: Some(receipt_path.into_std_path_buf()),
-                                error: Some(llm_err.to_string()),
-                            });
-                        }
-
-                        let packet_evidence = packet.evidence.clone();
-                        let mut flags = HashMap::new();
-                        flags.insert("phase".to_string(), phase_id.as_str().to_string());
-
-                        // Use config values for truthful failure receipts (no hard-coded metadata)
-                        let configured_model =
-                            config.config.get("model").map_or("unknown", |s| s.as_str());
-                        let configured_runner = config
-                            .config
-                            .get("runner_mode")
-                            .map_or("unknown", |s| s.as_str());
-
-                        let (exit_code, error_kind) =
-                            exit_codes::error_to_exit_code_and_kind(xchecker_err);
-
-                        let invocation =
-                            self.build_llm_invocation(phase_id, &prompt, &packet.content, config);
-                        let provider = self
-                            .config_from_orchestrator_config(config)
-                            .llm
-                            .provider
-                            .unwrap_or_else(|| "claude-cli".to_string());
-
-                        let mut llm_info = LlmInfo {
-                            provider: Some(provider),
-                            model_used: if invocation.model.is_empty() {
-                                None
-                            } else {
-                                Some(invocation.model.clone())
-                            },
-                            tokens_input: None,
-                            tokens_output: None,
-                            timed_out: None,
-                            timeout_seconds: Some(invocation.timeout.as_secs()),
-                            budget_exhausted: None,
-                        };
-
-                        let mut warnings = Vec::new();
-                        match llm_err {
-                            crate::llm::LlmError::Timeout { duration } => {
-                                llm_info.timed_out = Some(true);
-                                llm_info.timeout_seconds = Some(duration.as_secs());
-                                warnings.push(format!("phase_timeout:{}", duration.as_secs()));
-                            }
-                            _ => {
-                                llm_info.timed_out = Some(false);
-                                warnings.push(format!("llm_error:{}", llm_err));
-                            }
-                        }
-                        if let Some(ref warning) = llm_fallback_warning {
-                            warnings.push(warning.clone());
-                        }
-
-                        let mut receipt = self.receipt_manager().create_receipt_with_redactor(
-                            config.redactor.as_ref(),
-                            self.spec_id(),
-                            phase_id,
-                            exit_code,
-                            vec![], // No successful outputs
-                            env!("CARGO_PKG_VERSION"),
-                            "unknown", // Claude hasn't completed, so version is unknown
-                            configured_model,
-                            None, // No model alias
-                            flags,
-                            packet_evidence,
-                            None, // No stderr_tail
-                            None, // No stderr_redacted
-                            warnings,
-                            None, // No fallback
-                            configured_runner,
-                            None, // No runner distro
-                            Some(error_kind),
-                            Some(llm_err.to_string()),
-                            None, // No diff_context
-                            pipeline_info.clone(),
-                        );
-
-                        receipt.llm = Some(llm_info);
-
-                        let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
-
-                        return Ok(ExecutionResult {
-                            phase: phase_id,
-                            success: false,
-                            exit_code,
-                            artifact_paths: vec![],
-                            receipt_path: Some(receipt_path.into_std_path_buf()),
-                            error: Some(llm_err.to_string()),
-                        });
-                    }
-                    // For other errors, propagate normally
-                    return Err(e);
-                }
-            }
-        };
+                PhaseLlmOutcome::Completed {
+                    claude_response,
+                    claude_exit_code,
+                    claude_metadata,
+                    llm_result,
+                    llm_fallback_warning,
+                } => (
+                    claude_response,
+                    claude_exit_code,
+                    claude_metadata,
+                    llm_result,
+                    llm_fallback_warning,
+                ),
+                PhaseLlmOutcome::Failed(result) => return Ok(result),
+            };
 
         // Handle Claude CLI failure (R4.3)
         if claude_exit_code != 0 {
             // Save partial output as required by R4.3
-            let partial_filename = format!(
-                "{:02}-{}.partial.md",
-                self.get_phase_number(phase_id),
-                phase_id.as_str().to_lowercase()
-            );
-
-            let partial_result = self.artifact_manager().store_artifact(&Artifact {
-                name: partial_filename.clone(),
-                content: claude_response.clone(),
-                artifact_type: ArtifactType::Partial,
-                blake3_hash: blake3::hash(claude_response.as_bytes())
-                    .to_hex()
-                    .to_string(),
-            })?;
-            let partial_path = partial_result.path;
+            let (partial_filename, partial_path) =
+                self.store_failed_llm_partial(phase_id, &claude_response)?;
 
             // Create failure receipt with stderr_tail and warnings (R4.3)
             // Use the actual packet evidence from the packet that was created
@@ -1226,7 +795,7 @@ impl PhaseOrchestrator {
                 phase: phase_id,
                 success: false,
                 exit_code: claude_exit_code,
-                artifact_paths: vec![partial_path.into_std_path_buf()], // Include partial artifact
+                artifact_paths: vec![partial_path], // Include partial artifact
                 receipt_path: Some(receipt_path.into_std_path_buf()),
                 error: Some(enhanced_error.to_string()),
             });
@@ -1242,65 +811,8 @@ impl PhaseOrchestrator {
                 )
             })?;
 
-        // Step 7: Write partial artifacts to .partial/ subdirectory (FR-ORC-004)
-        let mut artifact_paths = Vec::new();
-        let mut output_hashes = Vec::new();
-        let mut atomic_write_warnings = Vec::new();
-
-        for artifact in &phase_result.artifacts {
-            // Store to .partial/ staging directory first
-            let partial_result = self
-                .artifact_manager()
-                .store_partial_staged_artifact(artifact)
-                .with_context(|| format!("Failed to store partial artifact: {}", artifact.name))?;
-
-            // Collect atomic write warnings
-            for warning in &partial_result.atomic_write_result.warnings {
-                atomic_write_warnings.push(format!("{}: {}", artifact.name, warning));
-            }
-
-            // Create file hash for receipt (using final content)
-            // Determine file type from extension for proper canonicalization
-            let file_type = if let Some(ext) = std::path::Path::new(&artifact.name).extension() {
-                FileType::from_extension(ext.to_str().unwrap_or(""))
-            } else {
-                // Fallback to artifact type if no extension
-                match artifact.artifact_type {
-                    ArtifactType::Markdown => FileType::Markdown,
-                    ArtifactType::CoreYaml => FileType::Yaml,
-                    _ => FileType::Text,
-                }
-            };
-
-            let file_hash = self
-                .receipt_manager()
-                .create_file_hash(
-                    &format!("artifacts/{}", artifact.name),
-                    &artifact.content,
-                    file_type,
-                    phase_id.as_str(),
-                )
-                .map_err(|e| {
-                    XCheckerError::Phase(PhaseError::OutputValidationFailed {
-                        phase: phase_id.as_str().to_string(),
-                        reason: e.to_string(),
-                    })
-                })?;
-
-            output_hashes.push(file_hash);
-        }
-
-        // Step 8: Promote to final (atomic rename) (FR-ORC-004)
-        for artifact in &phase_result.artifacts {
-            let final_path = self
-                .artifact_manager()
-                .promote_staged_to_final(&artifact.name)
-                .with_context(|| {
-                    format!("Failed to promote artifact to final: {}", artifact.name)
-                })?;
-
-            artifact_paths.push(final_path.into_std_path_buf());
-        }
+        // Steps 7-8: Stage, hash, and promote successful artifacts (FR-ORC-004).
+        let stored_artifacts = self.store_success_artifacts(phase_id, &phase_result.artifacts)?;
 
         // Step 9: Create and write receipt (FR-ORC-005, FR-ORC-006)
         // Use the actual packet evidence from the packet that was created
@@ -1318,7 +830,8 @@ impl PhaseOrchestrator {
             (None, "haiku".to_string())
         };
 
-        let mut warnings: Vec<String> = atomic_write_warnings
+        let mut warnings: Vec<String> = stored_artifacts
+            .atomic_write_warnings
             .into_iter()
             .chain(hook_warnings.iter().cloned())
             .collect();
@@ -1331,7 +844,7 @@ impl PhaseOrchestrator {
             self.spec_id(),
             phase_id,
             0, // Success exit code
-            output_hashes,
+            stored_artifacts.output_hashes,
             env!("CARGO_PKG_VERSION"),
             claude_metadata
                 .as_ref()
@@ -1363,62 +876,14 @@ impl PhaseOrchestrator {
             .write_receipt(&receipt)
             .with_context(|| format!("Failed to write receipt for phase: {}", phase_id.as_str()))?;
 
-        // Execute post-phase hook if configured (runs on success)
-        // Hooks run from invocation CWD so relative paths like ./scripts/... work
-        // Note: Post-hook failures are treated as warnings, not phase failures
-        // (artifacts have already been created and receipt written)
-        if let Some(ref hooks_config) = config.hooks
-            && let Some(hook_config) = hooks_config.get_post_phase_hook(phase_id)
-        {
-            let executor = HookExecutor::new(
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-            );
-            let context = HookContext::new(self.spec_id(), phase_id, HookType::PostPhase);
-
-            match execute_and_process_hook(
-                &executor,
-                hook_config,
-                &context,
-                HookType::PostPhase,
-                phase_id,
-            )
-            .await
-            {
-                Ok(outcome) => {
-                    // Log any warnings from successful or failed hooks
-                    if let Some(warning) = outcome.warning() {
-                        tracing::warn!(
-                            phase = %phase_id.as_str(),
-                            "Post-phase hook warning: {}",
-                            warning.to_warning_string()
-                        );
-                    }
-                    // Check if hook wanted to fail but we treat it as warning
-                    // (post-hooks run after artifacts are created, so we don't fail the phase)
-                    if !outcome.should_continue() {
-                        tracing::warn!(
-                            phase = %phase_id.as_str(),
-                            "Post-phase hook had on_fail=fail but phase artifacts already created; treating as warning"
-                        );
-                    }
-                }
-                Err(e) => {
-                    // Log hook execution errors but don't fail the phase
-                    // (artifacts are already created at this point)
-                    tracing::warn!(
-                        phase = %phase_id.as_str(),
-                        error = %e,
-                        "Post-phase hook execution error (treated as warning)"
-                    );
-                }
-            }
-        }
+        // Execute post-phase hook after artifacts and receipt are written.
+        self.run_post_phase_hook(phase_id, config).await;
 
         Ok(ExecutionResult {
             phase: phase_id,
             success: true,
             exit_code: 0,
-            artifact_paths,
+            artifact_paths: stored_artifacts.artifact_paths,
             receipt_path: Some(receipt_path.into_std_path_buf()),
             error: None,
         })

--- a/crates/xchecker-engine/src/orchestrator/phase_exec/artifacts.rs
+++ b/crates/xchecker-engine/src/orchestrator/phase_exec/artifacts.rs
@@ -1,0 +1,133 @@
+//! Artifact staging, promotion, and receipt hash preparation.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::error::{PhaseError, XCheckerError};
+use crate::status::artifact::{Artifact, ArtifactType};
+use crate::types::{FileHash, FileType, PhaseId};
+
+use crate::orchestrator::PhaseOrchestrator;
+
+pub(crate) struct StoredArtifacts {
+    pub artifact_paths: Vec<PathBuf>,
+    pub output_hashes: Vec<FileHash>,
+    pub atomic_write_warnings: Vec<String>,
+}
+
+impl PhaseOrchestrator {
+    /// Stage, hash, and promote all successful phase artifacts.
+    pub(crate) fn store_success_artifacts(
+        &self,
+        phase_id: PhaseId,
+        artifacts: &[Artifact],
+    ) -> Result<StoredArtifacts> {
+        let mut output_hashes = Vec::new();
+        let mut atomic_write_warnings = Vec::new();
+
+        for artifact in artifacts {
+            let partial_result = self
+                .artifact_manager()
+                .store_partial_staged_artifact(artifact)
+                .with_context(|| format!("Failed to store partial artifact: {}", artifact.name))?;
+
+            for warning in &partial_result.atomic_write_result.warnings {
+                atomic_write_warnings.push(format!("{}: {}", artifact.name, warning));
+            }
+
+            output_hashes.push(self.create_receipt_file_hash(phase_id, artifact)?);
+        }
+
+        let mut artifact_paths = Vec::new();
+        for artifact in artifacts {
+            let final_path = self
+                .artifact_manager()
+                .promote_staged_to_final(&artifact.name)
+                .with_context(|| {
+                    format!("Failed to promote artifact to final: {}", artifact.name)
+                })?;
+
+            artifact_paths.push(final_path.into_std_path_buf());
+        }
+
+        Ok(StoredArtifacts {
+            artifact_paths,
+            output_hashes,
+            atomic_write_warnings,
+        })
+    }
+
+    /// Stage and promote artifacts when the caller does not need receipt hashes.
+    pub(crate) fn store_core_phase_artifacts(&self, artifacts: &[Artifact]) -> Result<()> {
+        for artifact in artifacts {
+            self.artifact_manager()
+                .store_partial_staged_artifact(artifact)
+                .with_context(|| format!("Failed to store partial artifact: {}", artifact.name))?;
+        }
+
+        for artifact in artifacts {
+            self.artifact_manager()
+                .promote_staged_to_final(&artifact.name)
+                .with_context(|| {
+                    format!("Failed to promote artifact to final: {}", artifact.name)
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Persist failed LLM output as the phase partial artifact required by R4.3.
+    pub(crate) fn store_failed_llm_partial(
+        &self,
+        phase_id: PhaseId,
+        claude_response: &str,
+    ) -> Result<(String, PathBuf)> {
+        let partial_filename = format!(
+            "{:02}-{}.partial.md",
+            self.get_phase_number(phase_id),
+            phase_id.as_str().to_lowercase()
+        );
+
+        let partial_result = self.artifact_manager().store_artifact(&Artifact {
+            name: partial_filename.clone(),
+            content: claude_response.to_string(),
+            artifact_type: ArtifactType::Partial,
+            blake3_hash: blake3::hash(claude_response.as_bytes())
+                .to_hex()
+                .to_string(),
+        })?;
+
+        Ok((partial_filename, partial_result.path.into_std_path_buf()))
+    }
+
+    fn create_receipt_file_hash(&self, phase_id: PhaseId, artifact: &Artifact) -> Result<FileHash> {
+        let file_type = artifact_file_type(artifact);
+        self.receipt_manager()
+            .create_file_hash(
+                &format!("artifacts/{}", artifact.name),
+                &artifact.content,
+                file_type,
+                phase_id.as_str(),
+            )
+            .map_err(|e| {
+                XCheckerError::Phase(PhaseError::OutputValidationFailed {
+                    phase: phase_id.as_str().to_string(),
+                    reason: e.to_string(),
+                })
+                .into()
+            })
+    }
+}
+
+fn artifact_file_type(artifact: &Artifact) -> FileType {
+    if let Some(ext) = Path::new(&artifact.name).extension() {
+        return FileType::from_extension(ext.to_str().unwrap_or(""));
+    }
+
+    match artifact.artifact_type {
+        ArtifactType::Markdown => FileType::Markdown,
+        ArtifactType::CoreYaml => FileType::Yaml,
+        _ => FileType::Text,
+    }
+}

--- a/crates/xchecker-engine/src/orchestrator/phase_exec/hooks.rs
+++ b/crates/xchecker-engine/src/orchestrator/phase_exec/hooks.rs
@@ -1,0 +1,192 @@
+//! Pre/post phase hook execution and hook-specific failure receipts.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::exit_codes;
+use crate::hooks::{HookContext, HookExecutor, HookType, execute_and_process_hook};
+use crate::types::{ErrorKind, PacketEvidence, PhaseId, PipelineInfo};
+
+use super::ExecutionResult;
+use crate::orchestrator::{OrchestratorConfig, PhaseOrchestrator};
+
+pub(crate) enum PrePhaseHookResult {
+    Continue { warnings: Vec<String> },
+    Abort(ExecutionResult),
+}
+
+impl PhaseOrchestrator {
+    /// Run the configured pre-phase hook, creating an audit receipt if it aborts the phase.
+    pub(crate) async fn run_pre_phase_hook(
+        &self,
+        phase_id: PhaseId,
+        config: &OrchestratorConfig,
+        pipeline_info: Option<PipelineInfo>,
+    ) -> Result<PrePhaseHookResult> {
+        let Some(ref hooks_config) = config.hooks else {
+            return Ok(PrePhaseHookResult::Continue { warnings: vec![] });
+        };
+        let Some(hook_config) = hooks_config.get_pre_phase_hook(phase_id) else {
+            return Ok(PrePhaseHookResult::Continue { warnings: vec![] });
+        };
+
+        let executor = hook_executor();
+        let context = HookContext::new(self.spec_id(), phase_id, HookType::PrePhase);
+        let mut hook_warnings = Vec::new();
+
+        match execute_and_process_hook(
+            &executor,
+            hook_config,
+            &context,
+            HookType::PrePhase,
+            phase_id,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                if let Some(warning) = outcome.warning() {
+                    hook_warnings.push(warning.to_warning_string());
+                }
+                if outcome.should_continue() {
+                    Ok(PrePhaseHookResult::Continue {
+                        warnings: hook_warnings,
+                    })
+                } else {
+                    let error_reason = format!(
+                        "Pre-phase hook failed: {}",
+                        outcome.error().map(|e| e.to_string()).unwrap_or_default()
+                    );
+                    self.pre_phase_hook_failure_result(
+                        phase_id,
+                        config,
+                        pipeline_info,
+                        hook_warnings,
+                        "hook_failure",
+                        error_reason,
+                    )
+                }
+            }
+            Err(e) => {
+                let error_reason = format!("Pre-phase hook error: {}", e);
+                self.pre_phase_hook_failure_result(
+                    phase_id,
+                    config,
+                    pipeline_info,
+                    vec![format!("hook_error:pre_phase:{}", e)],
+                    "hook_error",
+                    error_reason,
+                )
+            }
+        }
+    }
+
+    /// Run post-phase hooks after successful artifact/receipt creation.
+    pub(crate) async fn run_post_phase_hook(&self, phase_id: PhaseId, config: &OrchestratorConfig) {
+        let Some(ref hooks_config) = config.hooks else {
+            return;
+        };
+        let Some(hook_config) = hooks_config.get_post_phase_hook(phase_id) else {
+            return;
+        };
+
+        let executor = hook_executor();
+        let context = HookContext::new(self.spec_id(), phase_id, HookType::PostPhase);
+
+        match execute_and_process_hook(
+            &executor,
+            hook_config,
+            &context,
+            HookType::PostPhase,
+            phase_id,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                if let Some(warning) = outcome.warning() {
+                    tracing::warn!(
+                        phase = %phase_id.as_str(),
+                        "Post-phase hook warning: {}",
+                        warning.to_warning_string()
+                    );
+                }
+                if !outcome.should_continue() {
+                    tracing::warn!(
+                        phase = %phase_id.as_str(),
+                        "Post-phase hook had on_fail=fail but phase artifacts already created; treating as warning"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    phase = %phase_id.as_str(),
+                    error = %e,
+                    "Post-phase hook execution error (treated as warning)"
+                );
+            }
+        }
+    }
+
+    fn pre_phase_hook_failure_result(
+        &self,
+        phase_id: PhaseId,
+        config: &OrchestratorConfig,
+        pipeline_info: Option<PipelineInfo>,
+        hook_warnings: Vec<String>,
+        flag_key: &str,
+        error_reason: String,
+    ) -> Result<PrePhaseHookResult> {
+        let packet_evidence = PacketEvidence {
+            files: vec![],
+            max_bytes: 65536,
+            max_lines: 1200,
+        };
+        let mut flags = HashMap::new();
+        flags.insert("phase".to_string(), phase_id.as_str().to_string());
+        flags.insert(flag_key.to_string(), "pre_phase".to_string());
+
+        let configured_model = config.config.get("model").map_or("unknown", |s| s.as_str());
+        let configured_runner = config
+            .config
+            .get("runner_mode")
+            .map_or("unknown", |s| s.as_str());
+
+        let receipt = self.receipt_manager().create_receipt_with_redactor(
+            config.redactor.as_ref(),
+            self.spec_id(),
+            phase_id,
+            exit_codes::codes::CLAUDE_FAILURE,
+            vec![],
+            env!("CARGO_PKG_VERSION"),
+            "unknown",
+            configured_model,
+            None,
+            flags,
+            packet_evidence,
+            None,
+            None,
+            hook_warnings,
+            None,
+            configured_runner,
+            None,
+            Some(ErrorKind::ClaudeFailure),
+            Some(error_reason.clone()),
+            None,
+            pipeline_info,
+        );
+
+        let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
+        Ok(PrePhaseHookResult::Abort(ExecutionResult {
+            phase: phase_id,
+            success: false,
+            exit_code: exit_codes::codes::CLAUDE_FAILURE,
+            artifact_paths: vec![],
+            receipt_path: Some(receipt_path.into_std_path_buf()),
+            error: Some(error_reason),
+        }))
+    }
+}
+
+fn hook_executor() -> HookExecutor {
+    HookExecutor::new(std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")))
+}

--- a/crates/xchecker-engine/src/orchestrator/phase_exec/llm.rs
+++ b/crates/xchecker-engine/src/orchestrator/phase_exec/llm.rs
@@ -1,0 +1,268 @@
+//! LLM invocation branching and invocation-error receipt generation.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::error::XCheckerError;
+use crate::exit_codes;
+use crate::packet::Packet;
+use crate::types::{ErrorKind, LlmInfo, PhaseId, PipelineInfo};
+
+use super::ExecutionResult;
+use crate::orchestrator::llm::{ClaudeExecutionMetadata, LlmInvocationError};
+use crate::orchestrator::{OrchestratorConfig, PhaseOrchestrator};
+
+pub(crate) enum PhaseLlmOutcome {
+    Completed {
+        claude_response: String,
+        claude_exit_code: i32,
+        claude_metadata: Option<ClaudeExecutionMetadata>,
+        llm_result: Option<crate::llm::LlmResult>,
+        llm_fallback_warning: Option<String>,
+    },
+    Failed(ExecutionResult),
+}
+
+impl PhaseOrchestrator {
+    /// Invoke the configured LLM or produce dry-run output, turning provider invocation errors into receipts.
+    pub(crate) async fn execute_llm_for_phase(
+        &self,
+        phase_id: PhaseId,
+        prompt: &str,
+        packet: &Packet,
+        config: &OrchestratorConfig,
+        pipeline_info: Option<PipelineInfo>,
+    ) -> Result<PhaseLlmOutcome> {
+        if config.dry_run {
+            return Ok(PhaseLlmOutcome::Completed {
+                claude_response: self.simulate_claude_response(phase_id, prompt),
+                claude_exit_code: 0,
+                claude_metadata: Some(ClaudeExecutionMetadata {
+                    model_alias: None,
+                    model_full_name: "haiku".to_string(),
+                    claude_cli_version: "0.8.1".to_string(),
+                    fallback_used: false,
+                    runner: "simulated".to_string(),
+                    runner_distro: None,
+                    stderr_tail: None,
+                }),
+                llm_result: Some(self.simulate_llm_result(phase_id)),
+                llm_fallback_warning: None,
+            });
+        }
+
+        match self
+            .run_llm_invocation(prompt, &packet.content, phase_id, config)
+            .await
+        {
+            Ok((response, exit_code, metadata, result, fallback_warning)) => {
+                Ok(PhaseLlmOutcome::Completed {
+                    claude_response: response,
+                    claude_exit_code: exit_code,
+                    claude_metadata: metadata,
+                    llm_result: result,
+                    llm_fallback_warning: fallback_warning,
+                })
+            }
+            Err(e) => {
+                let (xchecker_err, fallback_warning) =
+                    if let Some(invocation_err) = e.downcast_ref::<LlmInvocationError>() {
+                        (
+                            invocation_err.error(),
+                            invocation_err.fallback_warning().map(|s| s.to_string()),
+                        )
+                    } else if let Some(xchecker_err) = e.downcast_ref::<XCheckerError>() {
+                        (xchecker_err, None)
+                    } else {
+                        return Err(e);
+                    };
+
+                if let XCheckerError::Llm(llm_err) = xchecker_err {
+                    let result = self.llm_error_result(
+                        phase_id,
+                        prompt,
+                        packet,
+                        config,
+                        pipeline_info,
+                        xchecker_err,
+                        llm_err,
+                        fallback_warning,
+                    )?;
+                    return Ok(PhaseLlmOutcome::Failed(result));
+                }
+
+                Err(e)
+            }
+        }
+    }
+
+    fn llm_error_result(
+        &self,
+        phase_id: PhaseId,
+        prompt: &str,
+        packet: &Packet,
+        config: &OrchestratorConfig,
+        pipeline_info: Option<PipelineInfo>,
+        xchecker_err: &XCheckerError,
+        llm_err: &crate::llm::LlmError,
+        fallback_warning: Option<String>,
+    ) -> Result<ExecutionResult> {
+        if matches!(llm_err, crate::llm::LlmError::BudgetExceeded { .. }) {
+            return self.budget_exhaustion_result(
+                phase_id,
+                packet,
+                config,
+                pipeline_info,
+                llm_err,
+                fallback_warning,
+            );
+        }
+
+        let packet_evidence = packet.evidence.clone();
+        let mut flags = HashMap::new();
+        flags.insert("phase".to_string(), phase_id.as_str().to_string());
+
+        let configured_model = config.config.get("model").map_or("unknown", |s| s.as_str());
+        let configured_runner = config
+            .config
+            .get("runner_mode")
+            .map_or("unknown", |s| s.as_str());
+
+        let (exit_code, error_kind) = exit_codes::error_to_exit_code_and_kind(xchecker_err);
+
+        let invocation = self.build_llm_invocation(phase_id, prompt, &packet.content, config);
+        let provider = self
+            .config_from_orchestrator_config(config)
+            .llm
+            .provider
+            .unwrap_or_else(|| "claude-cli".to_string());
+
+        let mut llm_info = LlmInfo {
+            provider: Some(provider),
+            model_used: if invocation.model.is_empty() {
+                None
+            } else {
+                Some(invocation.model.clone())
+            },
+            tokens_input: None,
+            tokens_output: None,
+            timed_out: None,
+            timeout_seconds: Some(invocation.timeout.as_secs()),
+            budget_exhausted: None,
+        };
+
+        let mut warnings = Vec::new();
+        match llm_err {
+            crate::llm::LlmError::Timeout { duration } => {
+                llm_info.timed_out = Some(true);
+                llm_info.timeout_seconds = Some(duration.as_secs());
+                warnings.push(format!("phase_timeout:{}", duration.as_secs()));
+            }
+            _ => {
+                llm_info.timed_out = Some(false);
+                warnings.push(format!("llm_error:{}", llm_err));
+            }
+        }
+        if let Some(ref warning) = fallback_warning {
+            warnings.push(warning.clone());
+        }
+
+        let mut receipt = self.receipt_manager().create_receipt_with_redactor(
+            config.redactor.as_ref(),
+            self.spec_id(),
+            phase_id,
+            exit_code,
+            vec![],
+            env!("CARGO_PKG_VERSION"),
+            "unknown",
+            configured_model,
+            None,
+            flags,
+            packet_evidence,
+            None,
+            None,
+            warnings,
+            None,
+            configured_runner,
+            None,
+            Some(error_kind),
+            Some(llm_err.to_string()),
+            None,
+            pipeline_info,
+        );
+
+        receipt.llm = Some(llm_info);
+        let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
+
+        Ok(ExecutionResult {
+            phase: phase_id,
+            success: false,
+            exit_code,
+            artifact_paths: vec![],
+            receipt_path: Some(receipt_path.into_std_path_buf()),
+            error: Some(llm_err.to_string()),
+        })
+    }
+
+    fn budget_exhaustion_result(
+        &self,
+        phase_id: PhaseId,
+        packet: &Packet,
+        config: &OrchestratorConfig,
+        pipeline_info: Option<PipelineInfo>,
+        llm_err: &crate::llm::LlmError,
+        fallback_warning: Option<String>,
+    ) -> Result<ExecutionResult> {
+        let packet_evidence = packet.evidence.clone();
+        let mut flags = HashMap::new();
+        flags.insert("phase".to_string(), phase_id.as_str().to_string());
+
+        let configured_model = config.config.get("model").map_or("unknown", |s| s.as_str());
+        let configured_runner = config
+            .config
+            .get("runner_mode")
+            .map_or("unknown", |s| s.as_str());
+
+        let mut warnings = vec![format!("LLM budget exhausted: {}", llm_err)];
+        if let Some(ref warning) = fallback_warning {
+            warnings.push(warning.clone());
+        }
+
+        let mut receipt = self.receipt_manager().create_receipt_with_redactor(
+            config.redactor.as_ref(),
+            self.spec_id(),
+            phase_id,
+            exit_codes::codes::CLAUDE_FAILURE,
+            vec![],
+            env!("CARGO_PKG_VERSION"),
+            "unknown",
+            configured_model,
+            None,
+            flags,
+            packet_evidence,
+            None,
+            None,
+            warnings,
+            None,
+            configured_runner,
+            None,
+            Some(ErrorKind::ClaudeFailure),
+            Some(llm_err.to_string()),
+            None,
+            pipeline_info,
+        );
+
+        receipt.llm = Some(LlmInfo::for_budget_exhaustion());
+        let receipt_path = self.receipt_manager().write_receipt(&receipt)?;
+
+        Ok(ExecutionResult {
+            phase: phase_id,
+            success: false,
+            exit_code: exit_codes::codes::CLAUDE_FAILURE,
+            artifact_paths: vec![],
+            receipt_path: Some(receipt_path.into_std_path_buf()),
+            error: Some(llm_err.to_string()),
+        })
+    }
+}

--- a/crates/xchecker-engine/src/orchestrator/phase_exec/packet.rs
+++ b/crates/xchecker-engine/src/orchestrator/phase_exec/packet.rs
@@ -1,0 +1,82 @@
+//! Packet construction, redaction checks, and debug packet persistence.
+
+use anyhow::Result;
+
+use crate::error::{PhaseError, XCheckerError};
+use crate::packet::{Packet, PacketBuilder};
+use crate::phase::{Phase, PhaseContext};
+use crate::types::PhaseId;
+
+use crate::orchestrator::{OrchestratorConfig, PhaseOrchestrator};
+
+impl PhaseOrchestrator {
+    /// Build a phase packet and emit visibility telemetry about its hash and budget.
+    pub(crate) fn build_phase_packet(
+        &self,
+        phase: &dyn Phase,
+        phase_context: &PhaseContext,
+        phase_id: PhaseId,
+    ) -> Result<Packet> {
+        let packet = phase.make_packet(phase_context).map_err(|e| {
+            XCheckerError::Phase(PhaseError::PacketCreationFailed {
+                phase: phase_id.as_str().to_string(),
+                reason: e.to_string(),
+            })
+        })?;
+
+        let budget = packet.budget_usage();
+        tracing::info!(
+            target: "xchecker::packet",
+            spec_id = %self.spec_id(),
+            phase = %phase_id.as_str(),
+            packet_hash = %packet.hash(),
+            bytes_used = budget.bytes_used,
+            bytes_limit = budget.max_bytes,
+            lines_used = budget.lines_used,
+            lines_limit = budget.max_lines,
+            "Built packet for phase"
+        );
+
+        Ok(packet)
+    }
+
+    /// Persist packet context artifacts that are only written after secret scanning succeeds.
+    pub(crate) fn persist_packet_context(
+        &self,
+        phase_id: PhaseId,
+        packet_content: &str,
+        config: &OrchestratorConfig,
+    ) -> Result<()> {
+        self.artifact_manager()
+            .store_context_file(&format!("{}-packet", phase_id.as_str()), packet_content)?;
+
+        let debug_packet_enabled = config
+            .config
+            .get("debug_packet")
+            .is_some_and(|s| s == "true");
+
+        if debug_packet_enabled {
+            self.write_debug_packet(phase_id, packet_content)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_debug_packet(&self, phase_id: PhaseId, packet_content: &str) -> Result<()> {
+        let context_dir = self.artifact_manager().context_path();
+        let temp_builder = PacketBuilder::new().map_err(|e| {
+            XCheckerError::Phase(PhaseError::PacketCreationFailed {
+                phase: phase_id.as_str().to_string(),
+                reason: format!("Failed to create PacketBuilder for debug packet: {e}"),
+            })
+        })?;
+
+        if let Err(e) =
+            temp_builder.write_debug_packet(packet_content, phase_id.as_str(), &context_dir)
+        {
+            eprintln!("Warning: Failed to write debug packet: {e}");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation
- The single large phase execution implementation mixed packet construction, secret scanning, LLM invocation/error handling, artifact staging/promotion, and hook execution, making the function hard to read and maintain.
- Split responsibilities into focused helpers to follow the Single Responsibility Principle and make the execution flow easier to reason about and test.

### Description
- Extracted packet construction and debug-packet persistence into `phase_exec/packet.rs` and replaced inline packet logic with `build_phase_packet` and `persist_packet_context` calls in `phase_exec.rs`.
- Extracted artifact staging, promotion, and receipt hash preparation into `phase_exec/artifacts.rs` and replaced ad-hoc artifact loops with `store_core_phase_artifacts`, `store_success_artifacts`, and `store_failed_llm_partial` helpers.
- Extracted pre/post-phase hook orchestration and hook-failure receipt creation into `phase_exec/hooks.rs` and integrated with `execute_phase` via `run_pre_phase_hook` and `run_post_phase_hook` abstractions returning `PrePhaseHookResult`.
- Extracted LLM invocation branching and invocation-error → receipt conversion into `phase_exec/llm.rs` and wired `execute_phase` to use `execute_llm_for_phase` which returns a `PhaseLlmOutcome` enum.

### Testing
- Ran formatting check with `cargo fmt -p xchecker-engine -- --check` which succeeded.
- Ran `git diff --check` which reported no whitespace/merge issues.
- Ran `cargo check -p xchecker-engine`; the refactor compiles in the engine crate, however a pre-existing compile failure in another crate (`crates/xchecker-lock`) (missing `PartialEq`/`Eq` on `DriftPair` while `FlowLockDrift` derives them) blocks a full workspace `cargo check` pass and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0281967f7883339fcc9d08f095e438)