### PR TITLE
Refactor CLI helpers into SRP submodules

### DIFF
--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,6 @@
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use crossterm::style::{Color, Stylize};
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
@@ -30,50 +29,16 @@ use crate::redaction::SecretRedactor;
 use crate::source::SourceResolver;
 use crate::spec_id::sanitize_spec_id;
 
-/// Check if colored output should be used.
-///
-/// Returns true only if:
-/// - stdout is a terminal (TTY)
-/// - NO_COLOR environment variable is not set
-fn use_color() -> bool {
-    std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
-}
+mod json;
+mod locking;
+mod style;
 
-/// Return a styled check mark (✓) if colors are enabled, otherwise plain.
-fn styled_check() -> String {
-    if use_color() {
-        format!("{}", "✓".with(Color::Green).bold())
-    } else {
-        "✓".to_string()
-    }
-}
-
-/// Return a styled warning mark (⚠) if colors are enabled, otherwise plain.
-fn styled_warning() -> String {
-    if use_color() {
-        format!("{}", "⚠".with(Color::Yellow).bold())
-    } else {
-        "⚠".to_string()
-    }
-}
-
-/// Return styled success text if colors are enabled, otherwise plain.
-fn styled_success(text: &str) -> String {
-    if use_color() {
-        format!("{}", text.with(Color::Green).bold())
-    } else {
-        text.to_string()
-    }
-}
-
-/// Return styled info text (cyan) if colors are enabled, otherwise plain.
-fn styled_info(text: &str) -> String {
-    if use_color() {
-        format!("{}", text.with(Color::Cyan).bold())
-    } else {
-        text.to_string()
-    }
-}
+use json::{
+    emit_resume_json, emit_spec_json, emit_status_json, emit_workspace_history_json,
+    emit_workspace_status_json, generate_next_steps_hint,
+};
+use locking::{build_flow_context, check_lockfile_drift, detect_claude_cli_version};
+use style::{styled_check, styled_info, styled_success, styled_warning};
 
 /// xchecker - Claude orchestration tool for spec generation
 #[derive(Parser)]
@@ -1367,19 +1332,6 @@ fn execute_spec_json_command(spec_id: &str, config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Emit spec output as canonical JSON using JCS (RFC 8785)
-fn emit_spec_json(output: &crate::types::SpecOutput) -> Result<String> {
-    // Use emit_jcs from crate root for JCS canonicalization
-    emit_jcs(output).context("Failed to emit spec JSON")
-}
-
-/// Emit status output as canonical JSON using JCS (RFC 8785)
-/// Per FR-Claude Code-CLI (Requirements 4.1.2): Returns compact status summary
-fn emit_status_json(output: &crate::types::StatusJsonOutput) -> Result<String> {
-    // Use emit_jcs from crate root for JCS canonicalization
-    emit_jcs(output).context("Failed to emit status JSON")
-}
-
 /// Execute the resume --json command (FR-Claude Code-CLI: Claude Code CLI Surfaces)
 /// Returns JSON with schema_version, spec_id, phase, current_inputs, next_steps
 /// Excludes full packet and raw artifacts per Requirements 4.1.3, 4.1.4
@@ -1452,95 +1404,6 @@ fn execute_resume_json_command(spec_id: &str, phase_name: &str, config: &Config)
     println!("{json_output}");
 
     Ok(())
-}
-
-/// Generate next steps hint for resume JSON output
-fn generate_next_steps_hint(
-    spec_id: &str,
-    phase_id: PhaseId,
-    current_inputs: &crate::types::CurrentInputs,
-    _config: &Config,
-) -> String {
-    if !current_inputs.spec_exists {
-        return format!(
-            "Spec '{}' does not exist. Run 'xchecker spec {}' to create it first.",
-            spec_id, spec_id
-        );
-    }
-
-    // Check if we have the required inputs for this phase
-    let has_requirements = current_inputs
-        .available_artifacts
-        .iter()
-        .any(|a| a.contains("requirements"));
-    let has_design = current_inputs
-        .available_artifacts
-        .iter()
-        .any(|a| a.contains("design"));
-    let has_tasks = current_inputs
-        .available_artifacts
-        .iter()
-        .any(|a| a.contains("tasks"));
-    let has_review = current_inputs
-        .available_artifacts
-        .iter()
-        .any(|a| a.contains("review"));
-
-    match phase_id {
-        PhaseId::Requirements => {
-            "Run requirements phase to generate initial requirements from the problem statement."
-                .to_string()
-        }
-        PhaseId::Design => {
-            if has_requirements {
-                "Run design phase to generate architecture and design from requirements."
-                    .to_string()
-            } else {
-                format!(
-                    "Requirements phase not completed. Run 'xchecker resume {} --phase requirements' first.",
-                    spec_id
-                )
-            }
-        }
-        PhaseId::Tasks => {
-            if has_design {
-                "Run tasks phase to generate implementation tasks from design.".to_string()
-            } else {
-                format!(
-                    "Design phase not completed. Run 'xchecker resume {} --phase design' first.",
-                    spec_id
-                )
-            }
-        }
-        PhaseId::Review => {
-            if has_tasks {
-                "Run review phase to review and validate the generated spec.".to_string()
-            } else {
-                format!(
-                    "Tasks phase not completed. Run 'xchecker resume {} --phase tasks' first.",
-                    spec_id
-                )
-            }
-        }
-        PhaseId::Fixup => {
-            if has_review {
-                "Run fixup phase to apply any suggested changes from review.".to_string()
-            } else {
-                format!(
-                    "Review phase not completed. Run 'xchecker resume {} --phase review' first.",
-                    spec_id
-                )
-            }
-        }
-        PhaseId::Final => "Run final phase to complete the spec generation workflow.".to_string(),
-    }
-}
-
-/// Emit resume output as canonical JSON using JCS (RFC 8785)
-/// Per FR-Claude Code-CLI (Requirements 4.1.3): Returns resume context without full packet/artifacts
-fn emit_resume_json(output: &crate::types::ResumeJsonOutput) -> Result<String> {
-    // Use emit_jcs from crate root for JCS canonicalization
-    emit_jcs(output).context("Failed to emit resume JSON")
 }
 
 /// Execute the status command
@@ -3021,7 +2884,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3125,177 +2987,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     println!("     xchecker resume {spec_id} --phase requirements");
 
     Ok(())
-}
-
-/// Detect Claude CLI version by running `claude --version`
-fn detect_claude_cli_version() -> Result<String> {
-    use crate::runner::CommandSpec;
-
-    let output = CommandSpec::new("claude")
-        .arg("--version")
-        .to_command()
-        .output()
-        .context("Failed to execute 'claude --version'")?;
-
-    if !output.status.success() {
-        return Err(anyhow::anyhow!(
-            "claude --version exited with non-zero status"
-        ));
-    }
-
-    let version_str = String::from_utf8(output.stdout)
-        .context("Failed to parse claude --version output as UTF-8")?;
-
-    // Parse version from output (format: "claude 0.8.1" or similar)
-    let version = version_str
-        .split_whitespace()
-        .last()
-        .ok_or_else(|| anyhow::anyhow!("Failed to parse version from output"))?
-        .to_string();
-
-    Ok(version)
-}
-
-fn build_flow_context(config: &Config) -> crate::lock::FlowContext {
-    let execution_strategy = config
-        .llm
-        .execution_strategy
-        .as_deref()
-        .unwrap_or("controlled");
-    let provider = config.llm.provider.as_deref().unwrap_or("unspecified");
-    let prompt_template = config.llm.prompt_template.as_deref().unwrap_or("default");
-    let model = config.defaults.model.as_deref().unwrap_or("haiku");
-
-    crate::lock::FlowContext {
-        flow_version: format!("xchecker-kernel@{}", env!("CARGO_PKG_VERSION")),
-        stage_graph_version: "requirements-design-tasks-review-fixup-final.v1".to_string(),
-        gate_set_version: "xchecker-default-gates.v1".to_string(),
-        prompt_pack_version: format!("builtin:{prompt_template}"),
-        adapter_version: format!("strategy={execution_strategy};provider={provider}"),
-        provider_policy: format!("provider={provider};model={model}"),
-        tool_context_version: "builtin-tool-context.v1".to_string(),
-    }
-}
-
-/// Check for lockfile drift and warn or fail based on `strict_lock` flag
-fn check_lockfile_drift(
-    spec_id: &str,
-    strict_lock: bool,
-    model_full_name: &str,
-    claude_cli_version: &str,
-    config: &Config,
-) -> Result<Option<crate::types::LockDrift>> {
-    use crate::lock::{FlowLock, RunContext, XCheckerLock};
-
-    // Try to load lockfile
-    let lock = match XCheckerLock::load(spec_id) {
-        Ok(Some(lock)) => Some(lock),
-        Ok(None) => None,
-        Err(e) => {
-            eprintln!("⚠ Warning: Failed to load lockfile: {e}");
-            None
-        }
-    };
-
-    let legacy_drift = if let Some(lock) = lock {
-        let context = RunContext {
-            model_full_name: model_full_name.to_string(),
-            claude_cli_version: claude_cli_version.to_string(),
-            schema_version: "1".to_string(),
-        };
-        lock.detect_drift(&context)
-    } else {
-        None
-    };
-
-    let flow_drift = match FlowLock::load(spec_id) {
-        Ok(Some(lock)) => lock.detect_drift(&build_flow_context(config)),
-        Ok(None) => None,
-        Err(e) => {
-            eprintln!("⚠ Warning: Failed to load flow lock: {e}");
-            None
-        }
-    };
-
-    if let Some(drift) = &legacy_drift {
-        eprintln!("\n⚠ Lockfile drift detected for spec '{spec_id}':");
-
-        if let Some(model_drift) = &drift.model_full_name {
-            eprintln!("  Model: {} → {}", model_drift.locked, model_drift.current);
-        }
-
-        if let Some(cli_drift) = &drift.claude_cli_version {
-            eprintln!("  Claude CLI: {} → {}", cli_drift.locked, cli_drift.current);
-        }
-
-        if let Some(schema_drift) = &drift.schema_version {
-            eprintln!(
-                "  Schema: {} → {}",
-                schema_drift.locked, schema_drift.current
-            );
-        }
-    }
-
-    if let Some(drift) = &flow_drift {
-        eprintln!("\n⚠ Flow lock drift detected for spec '{spec_id}':");
-
-        if let Some(flow_version) = &drift.flow_version {
-            eprintln!(
-                "  Flow version: {} → {}",
-                flow_version.locked, flow_version.current
-            );
-        }
-        if let Some(stage_graph) = &drift.stage_graph_version {
-            eprintln!(
-                "  Stage graph: {} → {}",
-                stage_graph.locked, stage_graph.current
-            );
-        }
-        if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
-        }
-        if let Some(prompt_pack) = &drift.prompt_pack_version {
-            eprintln!(
-                "  Prompt pack: {} → {}",
-                prompt_pack.locked, prompt_pack.current
-            );
-        }
-        if let Some(adapter) = &drift.adapter_version {
-            eprintln!("  Adapter: {} → {}", adapter.locked, adapter.current);
-        }
-        if let Some(provider_policy) = &drift.provider_policy {
-            eprintln!(
-                "  Provider policy: {} → {}",
-                provider_policy.locked, provider_policy.current
-            );
-        }
-        if let Some(tool_context) = &drift.tool_context_version {
-            eprintln!(
-                "  Tool context: {} → {}",
-                tool_context.locked, tool_context.current
-            );
-        }
-    }
-
-    if strict_lock && (legacy_drift.is_some() || flow_drift.is_some()) {
-        eprintln!("\n✗ Strict lock mode enabled: failing due to drift");
-        eprintln!("  To proceed, either:");
-        eprintln!(
-            "    - Update the lockfiles: rm .xchecker/specs/{spec_id}/lock.json .xchecker/specs/{spec_id}/flow.lock && xchecker init {spec_id} --create-lock"
-        );
-        eprintln!("    - Remove --strict-lock flag to allow drift with warning");
-
-        return Err(anyhow::anyhow!("Lock drift detected in strict mode"));
-    }
-
-    if legacy_drift.is_some() || flow_drift.is_some() {
-        eprintln!("\n  Continuing with drift (use --strict-lock to fail on drift)");
-    }
-
-    Ok(legacy_drift)
 }
 
 struct SpinnerGuard {
@@ -5568,12 +5259,6 @@ fn count_pending_fixups_for_spec(spec_id: &str) -> u32 {
     crate::fixup::pending_fixups_for_spec(spec_id).targets
 }
 
-/// Emit workspace status output as canonical JSON using JCS (RFC 8785)
-fn emit_workspace_status_json(output: &crate::types::WorkspaceStatusJsonOutput) -> Result<String> {
-    // Use emit_jcs from crate root for JCS canonicalization
-    emit_jcs(output).context("Failed to emit workspace status JSON")
-}
-
 /// Execute the project history command
 /// Per FR-WORKSPACE (Requirements 4.3.5): Emits timeline of phase progression
 fn execute_project_history_command(spec_id: &str, json: bool) -> Result<()> {
@@ -5768,14 +5453,6 @@ fn execute_project_history_command(spec_id: &str, json: bool) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Emit workspace history output as canonical JSON using JCS (RFC 8785)
-fn emit_workspace_history_json(
-    output: &crate::types::WorkspaceHistoryJsonOutput,
-) -> Result<String> {
-    // Use emit_jcs from crate root for JCS canonicalization
-    emit_jcs(output).context("Failed to emit workspace history JSON")
 }
 
 /// Execute the project TUI command

--- a/src/cli/json.rs
+++ b/src/cli/json.rs
@@ -1,0 +1,115 @@
+use anyhow::{Context, Result};
+
+use crate::{Config, PhaseId, emit_jcs};
+
+/// Emit spec output as canonical JSON using JCS (RFC 8785)
+pub(crate) fn emit_spec_json(output: &crate::types::SpecOutput) -> Result<String> {
+    emit_jcs(output).context("Failed to emit spec JSON")
+}
+
+/// Emit status output as canonical JSON using JCS (RFC 8785)
+/// Per FR-Claude Code-CLI (Requirements 4.1.2): Returns compact status summary
+pub(crate) fn emit_status_json(output: &crate::types::StatusJsonOutput) -> Result<String> {
+    emit_jcs(output).context("Failed to emit status JSON")
+}
+
+/// Generate next steps hint for resume JSON output
+pub(crate) fn generate_next_steps_hint(
+    spec_id: &str,
+    phase_id: PhaseId,
+    current_inputs: &crate::types::CurrentInputs,
+    _config: &Config,
+) -> String {
+    if !current_inputs.spec_exists {
+        return format!(
+            "Spec '{}' does not exist. Run 'xchecker spec {}' to create it first.",
+            spec_id, spec_id
+        );
+    }
+
+    let has_requirements = current_inputs
+        .available_artifacts
+        .iter()
+        .any(|a| a.contains("requirements"));
+    let has_design = current_inputs
+        .available_artifacts
+        .iter()
+        .any(|a| a.contains("design"));
+    let has_tasks = current_inputs
+        .available_artifacts
+        .iter()
+        .any(|a| a.contains("tasks"));
+    let has_review = current_inputs
+        .available_artifacts
+        .iter()
+        .any(|a| a.contains("review"));
+
+    match phase_id {
+        PhaseId::Requirements => {
+            "Run requirements phase to generate initial requirements from the problem statement."
+                .to_string()
+        }
+        PhaseId::Design => {
+            if has_requirements {
+                "Run design phase to generate architecture and design from requirements."
+                    .to_string()
+            } else {
+                format!(
+                    "Requirements phase not completed. Run 'xchecker resume {} --phase requirements' first.",
+                    spec_id
+                )
+            }
+        }
+        PhaseId::Tasks => {
+            if has_design {
+                "Run tasks phase to generate implementation tasks from design.".to_string()
+            } else {
+                format!(
+                    "Design phase not completed. Run 'xchecker resume {} --phase design' first.",
+                    spec_id
+                )
+            }
+        }
+        PhaseId::Review => {
+            if has_tasks {
+                "Run review phase to review and validate the generated spec.".to_string()
+            } else {
+                format!(
+                    "Tasks phase not completed. Run 'xchecker resume {} --phase tasks' first.",
+                    spec_id
+                )
+            }
+        }
+        PhaseId::Fixup => {
+            if has_review {
+                "Run fixup phase to apply any suggested changes from review.".to_string()
+            } else {
+                format!(
+                    "Review phase not completed. Run 'xchecker resume {} --phase review' first.",
+                    spec_id
+                )
+            }
+        }
+        PhaseId::Final => "Run final phase to complete the spec generation workflow.".to_string(),
+    }
+}
+
+/// Emit resume output as canonical JSON using JCS (RFC 8785)
+/// Per FR-Claude Code-CLI (Requirements 4.1.3): Returns resume context without full packet/artifacts
+pub(crate) fn emit_resume_json(output: &crate::types::ResumeJsonOutput) -> Result<String> {
+    emit_jcs(output).context("Failed to emit resume JSON")
+}
+
+/// Emit workspace status output as canonical JSON using JCS (RFC 8785)
+pub(crate) fn emit_workspace_status_json(
+    output: &crate::types::WorkspaceStatusJsonOutput,
+) -> Result<String> {
+    emit_jcs(output).context("Failed to emit workspace status JSON")
+}
+
+/// Emit workspace history output as canonical JSON using JCS (RFC 8785)
+pub(crate) fn emit_workspace_history_json(
+    output: &crate::types::WorkspaceHistoryJsonOutput,
+) -> Result<String> {
+    emit_jcs(output).context("Failed to emit workspace history JSON")
+}

--- a/src/cli/locking.rs
+++ b/src/cli/locking.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+
+use crate::Config;
+
+/// Detect Claude CLI version by running `claude --version`
+pub(crate) fn detect_claude_cli_version() -> Result<String> {
+    use crate::runner::CommandSpec;
+
+    let output = CommandSpec::new("claude")
+        .arg("--version")
+        .to_command()
+        .output()
+        .context("Failed to execute 'claude --version'")?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "claude --version exited with non-zero status"
+        ));
+    }
+
+    let version_str = String::from_utf8(output.stdout)
+        .context("Failed to parse claude --version output as UTF-8")?;
+
+    let version = version_str
+        .split_whitespace()
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("Failed to parse version from output"))?
+        .to_string();
+
+    Ok(version)
+}
+
+pub(crate) fn build_flow_context(config: &Config) -> crate::lock::FlowContext {
+    let execution_strategy = config
+        .llm
+        .execution_strategy
+        .as_deref()
+        .unwrap_or("controlled");
+    let provider = config.llm.provider.as_deref().unwrap_or("unspecified");
+    let prompt_template = config.llm.prompt_template.as_deref().unwrap_or("default");
+    let model = config.defaults.model.as_deref().unwrap_or("haiku");
+
+    crate::lock::FlowContext {
+        flow_version: format!("xchecker-kernel@{}", env!("CARGO_PKG_VERSION")),
+        stage_graph_version: "requirements-design-tasks-review-fixup-final.v1".to_string(),
+        gate_set_version: "xchecker-default-gates.v1".to_string(),
+        prompt_pack_version: format!("builtin:{prompt_template}"),
+        adapter_version: format!("strategy={execution_strategy};provider={provider}"),
+        provider_policy: format!("provider={provider};model={model}"),
+        tool_context_version: "builtin-tool-context.v1".to_string(),
+    }
+}
+
+/// Check for lockfile drift and warn or fail based on `strict_lock` flag
+pub(crate) fn check_lockfile_drift(
+    spec_id: &str,
+    strict_lock: bool,
+    model_full_name: &str,
+    claude_cli_version: &str,
+    config: &Config,
+) -> Result<Option<crate::types::LockDrift>> {
+    use crate::lock::{FlowLock, RunContext, XCheckerLock};
+
+    let lock = match XCheckerLock::load(spec_id) {
+        Ok(Some(lock)) => Some(lock),
+        Ok(None) => None,
+        Err(e) => {
+            eprintln!("⚠ Warning: Failed to load lockfile: {e}");
+            None
+        }
+    };
+
+    let legacy_drift = if let Some(lock) = lock {
+        let context = RunContext {
+            model_full_name: model_full_name.to_string(),
+            claude_cli_version: claude_cli_version.to_string(),
+            schema_version: "1".to_string(),
+        };
+        lock.detect_drift(&context)
+    } else {
+        None
+    };
+
+    let flow_drift = match FlowLock::load(spec_id) {
+        Ok(Some(lock)) => lock.detect_drift(&build_flow_context(config)),
+        Ok(None) => None,
+        Err(e) => {
+            eprintln!("⚠ Warning: Failed to load flow lock: {e}");
+            None
+        }
+    };
+
+    if let Some(drift) = &legacy_drift {
+        eprintln!("\n⚠ Lockfile drift detected for spec '{spec_id}':");
+
+        if let Some(model_drift) = &drift.model_full_name {
+            eprintln!("  Model: {} → {}", model_drift.locked, model_drift.current);
+        }
+
+        if let Some(cli_drift) = &drift.claude_cli_version {
+            eprintln!("  Claude CLI: {} → {}", cli_drift.locked, cli_drift.current);
+        }
+
+        if let Some(schema_drift) = &drift.schema_version {
+            eprintln!(
+                "  Schema: {} → {}",
+                schema_drift.locked, schema_drift.current
+            );
+        }
+    }
+
+    if let Some(drift) = &flow_drift {
+        eprintln!("\n⚠ Flow lock drift detected for spec '{spec_id}':");
+
+        if let Some(flow_version) = &drift.flow_version {
+            eprintln!(
+                "  Flow version: {} → {}",
+                flow_version.locked, flow_version.current
+            );
+        }
+        if let Some(stage_graph) = &drift.stage_graph_version {
+            eprintln!(
+                "  Stage graph: {} → {}",
+                stage_graph.locked, stage_graph.current
+            );
+        }
+        if let Some(gate_set) = &drift.gate_set_version {
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
+        }
+        if let Some(prompt_pack) = &drift.prompt_pack_version {
+            eprintln!(
+                "  Prompt pack: {} → {}",
+                prompt_pack.locked, prompt_pack.current
+            );
+        }
+        if let Some(adapter) = &drift.adapter_version {
+            eprintln!("  Adapter: {} → {}", adapter.locked, adapter.current);
+        }
+        if let Some(provider_policy) = &drift.provider_policy {
+            eprintln!(
+                "  Provider policy: {} → {}",
+                provider_policy.locked, provider_policy.current
+            );
+        }
+        if let Some(tool_context) = &drift.tool_context_version {
+            eprintln!(
+                "  Tool context: {} → {}",
+                tool_context.locked, tool_context.current
+            );
+        }
+    }
+
+    if strict_lock && (legacy_drift.is_some() || flow_drift.is_some()) {
+        eprintln!("\n✗ Strict lock mode enabled: failing due to drift");
+        eprintln!("  To proceed, either:");
+        eprintln!(
+            "    - Update the lockfiles: rm .xchecker/specs/{spec_id}/lock.json .xchecker/specs/{spec_id}/flow.lock && xchecker init {spec_id} --create-lock"
+        );
+        eprintln!("    - Remove --strict-lock flag to allow drift with warning");
+
+        return Err(anyhow::anyhow!("Lock drift detected in strict mode"));
+    }
+
+    if legacy_drift.is_some() || flow_drift.is_some() {
+        eprintln!("\n  Continuing with drift (use --strict-lock to fail on drift)");
+    }
+
+    Ok(legacy_drift)
+}

--- a/src/cli/style.rs
+++ b/src/cli/style.rs
@@ -1,0 +1,47 @@
+use crossterm::style::{Color, Stylize};
+use std::io::IsTerminal;
+
+/// Check if colored output should be used.
+///
+/// Returns true only if:
+/// - stdout is a terminal (TTY)
+/// - NO_COLOR environment variable is not set
+fn use_color() -> bool {
+    std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+}
+
+/// Return a styled check mark (✓) if colors are enabled, otherwise plain.
+pub(crate) fn styled_check() -> String {
+    if use_color() {
+        format!("{}", "✓".with(Color::Green).bold())
+    } else {
+        "✓".to_string()
+    }
+}
+
+/// Return a styled warning mark (⚠) if colors are enabled, otherwise plain.
+pub(crate) fn styled_warning() -> String {
+    if use_color() {
+        format!("{}", "⚠".with(Color::Yellow).bold())
+    } else {
+        "⚠".to_string()
+    }
+}
+
+/// Return styled success text if colors are enabled, otherwise plain.
+pub(crate) fn styled_success(text: &str) -> String {
+    if use_color() {
+        format!("{}", text.with(Color::Green).bold())
+    } else {
+        text.to_string()
+    }
+}
+
+/// Return styled info text (cyan) if colors are enabled, otherwise plain.
+pub(crate) fn styled_info(text: &str) -> String {
+    if use_color() {
+        format!("{}", text.with(Color::Cyan).bold())
+    } else {
+        text.to_string()
+    }
+}


### PR DESCRIPTION
### Motivation
- The single large `src/cli.rs` contained multiple helper responsibilities (JSON emission, lock/version drift, and terminal styling) making it hard to maintain and test. 
- Isolate focused functionality behind small modules to follow the Single Responsibility Principle and make the CLI orchestration layer clearer. 
- Fix a compile-time equality/derive issue in the lock types so drift comparisons compile reliably.

### Description
- Extracted JSON emitters and resume-hint logic into a new module `src/cli/json.rs` and updated `src/cli.rs` to call `emit_spec_json`, `emit_status_json`, `emit_resume_json`, `emit_workspace_status_json`, `emit_workspace_history_json`, and `generate_next_steps_hint` from that module. 
- Extracted flow/lock/version helpers into `src/cli/locking.rs` and exposed `detect_claude_cli_version`, `build_flow_context`, and `check_lockfile_drift` for use by `src/cli.rs`. 
- Extracted terminal color/styling helpers into `src/cli/style.rs` and imported `styled_check`, `styled_info`, `styled_success`, and `styled_warning` from it. 
- Updated `src/cli.rs` to act as the orchestration layer only, removing the moved helper implementations and adding `mod json; mod locking; mod style;` plus `use` imports. 
- Fixed `DriftPair` equality derives by adding `#[derive(PartialEq, Eq)]` to `crates/xchecker-lock/src/lib.rs` so `FlowLockDrift` can derive `PartialEq`/`Eq` without errors. 
- Minor formatting/readability tweaks where long expressions were wrapped to satisfy style checks.

### Testing
- Ran `cargo check -p xchecker --all-targets` and it completed successfully. 
- Ran `cargo fmt -- --check` and `cargo test -p xchecker --lib --bins`, both of which passed (unit tests for the CLI target all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bdb8199083339015a1d12a3dc1cb)