### PR TITLE
Harden fixup target file validation

### DIFF
--- a/crates/xchecker-engine/src/fixup/apply.rs
+++ b/crates/xchecker-engine/src/fixup/apply.rs
@@ -161,16 +161,10 @@ impl FixupParser {
     fn apply_single_diff_atomic(&self, diff: &UnifiedDiff) -> Result<AppliedFile, FixupError> {
         use std::fs;
 
-        // Validate and get the sandboxed target path
-        // This ensures the path is within the sandbox root and passes all security checks
-        let sandbox_path = self.validate_target_path(&diff.target_file)?;
+        // Validate and get the sandboxed target path.
+        // This ensures the path is within the sandbox root, exists, and is a regular file.
+        let sandbox_path = self.validate_existing_target_file(&diff.target_file)?;
         let target_path = sandbox_path.as_path();
-
-        if !target_path.exists() {
-            return Err(FixupError::TargetFileNotFound {
-                path: diff.target_file.clone(),
-            });
-        }
 
         let mut file_warnings = Vec::new();
 
@@ -446,15 +440,9 @@ impl FixupParser {
     ///
     /// The target path is validated through `SandboxRoot::join()` before any file operations.
     fn validate_diff_with_git_apply(&self, diff: &UnifiedDiff) -> Result<Vec<String>, FixupError> {
-        // Validate and get the sandboxed target path
-        let sandbox_path = self.validate_target_path(&diff.target_file)?;
+        // Validate and get the sandboxed target path.
+        let sandbox_path = self.validate_existing_target_file(&diff.target_file)?;
         let target_path = sandbox_path.as_path();
-
-        if !target_path.exists() {
-            return Err(FixupError::TargetFileNotFound {
-                path: diff.target_file.clone(),
-            });
-        }
 
         // Create temporary directory and copy target file
         let temp_dir = TempDir::new().map_err(|e| FixupError::TempCopyFailed {
@@ -516,15 +504,8 @@ impl FixupParser {
     ///
     /// The target path is validated through `SandboxRoot::join()` before any file operations.
     fn apply_single_diff(&self, diff: &UnifiedDiff) -> Result<bool, FixupError> {
-        // Validate and get the sandboxed target path
-        let sandbox_path = self.validate_target_path(&diff.target_file)?;
-        let target_path = sandbox_path.as_path();
-
-        if !target_path.exists() {
-            return Err(FixupError::TargetFileNotFound {
-                path: diff.target_file.clone(),
-            });
-        }
+        // Validate and get the sandboxed target path.
+        self.validate_existing_target_file(&diff.target_file)?;
 
         // Write diff to temporary file
         let temp_dir = TempDir::new().map_err(|e| FixupError::TempCopyFailed {
@@ -678,5 +659,36 @@ FIXUP PLAN:
         let (added, removed) = parser.calculate_change_stats(&diffs[0]);
         assert_eq!(added, 2); // +let x = 1; and +let z = 4;
         assert_eq!(removed, 1); // -let z = 3;
+    }
+    #[test]
+    fn test_preview_rejects_directory_target_before_git_apply() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("src");
+        std::fs::create_dir(&src_dir).unwrap();
+        let parser = FixupParser::new(FixupMode::Preview, temp_dir.path().to_path_buf()).unwrap();
+
+        let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/src
++++ b/src
+@@ -1 +1 @@
+-old
++new
+```
+"#;
+
+        let diffs = parser.parse_diffs(content).unwrap();
+        let preview = parser.preview_changes(&diffs).unwrap();
+
+        assert!(!preview.all_valid);
+        assert!(
+            preview
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Target path is not a regular file: src"))
+        );
+        assert_eq!(preview.change_summary["src"].validation_passed, false);
     }
 }

--- a/crates/xchecker-engine/src/fixup/parse.rs
+++ b/crates/xchecker-engine/src/fixup/parse.rs
@@ -124,6 +124,28 @@ impl FixupParser {
         })
     }
 
+    /// Validate and resolve an existing regular-file target within the sandbox.
+    pub(super) fn validate_existing_target_file(
+        &self,
+        target_file: &str,
+    ) -> Result<SandboxPath, FixupError> {
+        let sandbox_path = self.validate_target_path(target_file)?;
+        let target_path = sandbox_path.as_path();
+
+        if !target_path.exists() {
+            return Err(FixupError::TargetFileNotFound {
+                path: target_file.to_string(),
+            });
+        }
+        if !target_path.is_file() {
+            return Err(FixupError::TargetNotRegularFile {
+                path: target_file.to_string(),
+            });
+        }
+
+        Ok(sandbox_path)
+    }
+
     /// Detect if review output contains fixup markers.
     #[must_use]
     pub fn has_fixup_markers(&self, content: &str) -> bool {

--- a/crates/xchecker-engine/src/fixup/paths.rs
+++ b/crates/xchecker-engine/src/fixup/paths.rs
@@ -57,8 +57,14 @@ pub fn validate_fixup_target(
 
     let sandbox_root = SandboxRoot::new(repo_root, config).map_err(map_root_err)?;
     let sandbox_path = sandbox_root.join(path).map_err(map_join_err)?;
-    if !sandbox_path.as_path().exists() {
+    let target_path = sandbox_path.as_path();
+    if !target_path.exists() {
         return Err(FixupError::TargetFileNotFound {
+            path: path.display().to_string(),
+        });
+    }
+    if !target_path.is_file() {
+        return Err(FixupError::TargetNotRegularFile {
             path: path.display().to_string(),
         });
     }
@@ -442,6 +448,36 @@ mod tests {
         let upper_case = std::path::Path::new("TEST.TXT");
         let result2 = validate_fixup_target(upper_case, repo_root, false);
         assert!(result2.is_ok());
+    }
+
+    #[test]
+    fn test_validate_fixup_target_rejects_directory_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_root = temp_dir.path();
+        let src_dir = repo_root.join("src");
+        fs::create_dir(&src_dir).unwrap();
+
+        let result = validate_fixup_target(std::path::Path::new("src"), repo_root, false);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FixupError::TargetNotRegularFile { .. }
+        ));
+    }
+
+    #[test]
+    fn test_validate_fixup_target_rejects_repo_root_targets() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_root = temp_dir.path();
+
+        for target in ["", "."] {
+            let result = validate_fixup_target(std::path::Path::new(target), repo_root, false);
+            assert!(result.is_err(), "expected {target:?} to be rejected");
+            assert!(matches!(
+                result.unwrap_err(),
+                FixupError::TargetNotRegularFile { .. }
+            ));
+        }
     }
 
     #[test]

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/crates/xchecker-utils/src/error.rs
+++ b/crates/xchecker-utils/src/error.rs
@@ -1124,6 +1124,9 @@ pub enum FixupError {
     #[error("Target file not found: {path}")]
     TargetFileNotFound { path: String },
 
+    #[error("Target path is not a regular file: {path}")]
+    TargetNotRegularFile { path: String },
+
     #[error("Failed to create temporary copy of {file}: {reason}")]
     TempCopyFailed { file: String, reason: String },
 
@@ -1188,6 +1191,9 @@ impl UserFriendlyError for FixupError {
             Self::TargetFileNotFound { path } => {
                 format!("Target file '{path}' does not exist")
             }
+            Self::TargetNotRegularFile { path } => {
+                format!("Target path '{path}' is not a regular file")
+            }
             Self::TempCopyFailed { file, reason } => {
                 format!("Could not create temporary copy of '{file}': {reason}")
             }
@@ -1248,6 +1254,9 @@ impl UserFriendlyError for FixupError {
             }
             Self::TargetFileNotFound { .. } => {
                 Some("Fixup targets must exist in the repository before changes can be applied.".to_string())
+            }
+            Self::TargetNotRegularFile { .. } => {
+                Some("Fixup targets must be regular files; directories and other special file types cannot be patched.".to_string())
             }
             Self::TempCopyFailed { .. } => {
                 Some("Temporary copies are created to safely test changes before applying them.".to_string())
@@ -1312,6 +1321,12 @@ impl UserFriendlyError for FixupError {
                 "The file may have been deleted or moved since the review phase".to_string(),
                 "Check the file path is correct and relative to the repository root".to_string(),
                 "Run the review phase again to generate fresh fixup plans".to_string(),
+            ],
+            Self::TargetNotRegularFile { path } => vec![
+                format!("Use a regular file path instead of '{}'", path),
+                "Directories cannot be used as fixup targets".to_string(),
+                "Check the diff header's +++ path and regenerate the fixup plan if needed"
+                    .to_string(),
             ],
             Self::TempCopyFailed { file, reason } => vec![
                 "Check available disk space for temporary files".to_string(),
@@ -1386,9 +1401,9 @@ impl UserFriendlyError for FixupError {
                 ErrorCategory::Security
             }
             Self::SymlinkNotAllowed(_) | Self::HardlinkNotAllowed(_) => ErrorCategory::Security,
-            Self::TargetFileNotFound { .. } | Self::TempCopyFailed { .. } => {
-                ErrorCategory::FileSystem
-            }
+            Self::TargetFileNotFound { .. }
+            | Self::TargetNotRegularFile { .. }
+            | Self::TempCopyFailed { .. } => ErrorCategory::FileSystem,
             Self::CanonicalizationError(_) => ErrorCategory::FileSystem,
             Self::GitApplyValidationFailed { .. } | Self::GitApplyExecutionFailed { .. } => {
                 ErrorCategory::PhaseExecution

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(


### PR DESCRIPTION
### Motivation
- Prevent fixup application from operating on directories, repo-root targets (`""`/`.`) or other non-regular paths by validating targets early. 
- Centralize and tighten path checks so preview/validation and apply code follow the same policy and avoid unsafe file operations.
- Provide clearer user-facing errors for these edge cases and ensure related types used in equality comparisons derive required traits.

### Description
- Add a new `FixupError::TargetNotRegularFile` variant and user-facing messages/suggestions in `crates/xchecker-utils/src/error.rs` to surface non-regular-file targets. 
- Strengthen `validate_fixup_target` in `crates/xchecker-engine/src/fixup/paths.rs` to check `exists()` and `is_file()` and return `TargetNotRegularFile` when appropriate. 
- Add `validate_existing_target_file` helper in `crates/xchecker-engine/src/fixup/parse.rs` and route preview, atomic-apply, and legacy git-apply validation through it in `crates/xchecker-engine/src/fixup/apply.rs`. 
- Add edge-case tests for directory targets and repo-root targets and a preview-mode test that rejects directory targets before git-apply/copy logic (`crates/xchecker-engine/src/fixup/*` tests). 
- Derive `PartialEq`/`Eq` for `DriftPair` in `crates/xchecker-lock` to satisfy equality requirements used by `FlowLockDrift` comparisons; small formatting cleanups in `src/cli.rs`.

### Testing
- Ran `cargo test -p xchecker-engine fixup --lib` and all fixup unit tests passed. 
- Ran `cargo test -p xchecker-lock --lib` and lock crate tests passed. 
- Ran `cargo fmt -- --check` to validate formatting and it succeeded. 
- Ran `cargo test --workspace --lib` and the workspace test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ea60dc8333894c20df4c2d03ab)