### PR TITLE
Handle no-newline markers in fixup diffs; add tests and small cleanups

### DIFF
--- a/crates/xchecker-engine/src/fixup/apply.rs
+++ b/crates/xchecker-engine/src/fixup/apply.rs
@@ -294,6 +294,7 @@ impl FixupParser {
             let context_lines: Vec<&str> = hunk_lines
                 .iter()
                 .skip(1) // Skip @@ header
+                .filter(|line| !is_no_newline_marker(line))
                 .filter(|line| {
                     // Include context lines (starting with ' ') and removed lines (starting with '-')
                     // but NOT added lines (starting with '+') as those don't exist in the original file
@@ -376,6 +377,8 @@ impl FixupParser {
                 } else if line.starts_with(' ') {
                     // Context line - just advance
                     file_idx += 1;
+                } else if is_no_newline_marker(line) {
+                    // Unified diff metadata for the preceding line, not file content.
                 } else if !line.starts_with("@@") {
                     // Context line without leading space
                     file_idx += 1;
@@ -388,7 +391,11 @@ impl FixupParser {
             cumulative_offset += additions - deletions;
         }
 
-        Ok(lines.join("\n") + "\n")
+        let mut result = lines.join("\n");
+        if diff_new_content_has_trailing_newline(diff) {
+            result.push('\n');
+        }
+        Ok(result)
     }
 
     /// Compute BLAKE3 hash of content
@@ -616,6 +623,38 @@ impl FixupParser {
     }
 }
 
+fn is_no_newline_marker(line: &str) -> bool {
+    line == r"\ No newline at end of file"
+}
+
+fn diff_line_contributes_to_new_file(line: &str) -> bool {
+    (line.starts_with('+') && !line.starts_with("+++"))
+        || line.starts_with(' ')
+        || (!line.starts_with('-') && !line.starts_with("@@"))
+}
+
+fn diff_new_content_has_trailing_newline(diff: &UnifiedDiff) -> bool {
+    let mut new_content_has_trailing_newline = true;
+
+    for hunk in &diff.hunks {
+        let mut previous_diff_line: Option<&str> = None;
+        for line in hunk.content.lines().skip(1) {
+            if is_no_newline_marker(line) {
+                if previous_diff_line.is_some_and(diff_line_contributes_to_new_file) {
+                    new_content_has_trailing_newline = false;
+                }
+            } else {
+                previous_diff_line = Some(line);
+                if diff_line_contributes_to_new_file(line) {
+                    new_content_has_trailing_newline = true;
+                }
+            }
+        }
+    }
+
+    new_content_has_trailing_newline
+}
+
 /// Normalize line endings to LF (FR-FIX-010, FR-FS-004, FR-FS-005)
 ///
 /// This function converts all line ending styles (CRLF, CR, LF) to LF.
@@ -678,5 +717,62 @@ FIXUP PLAN:
         let (added, removed) = parser.calculate_change_stats(&diffs[0]);
         assert_eq!(added, 2); // +let x = 1; and +let z = 4;
         assert_eq!(removed, 1); // -let z = 3;
+    }
+
+    #[test]
+    fn apply_diff_handles_no_newline_marker_on_replacement() {
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("no_newline.txt");
+        std::fs::write(&target_file, "old").unwrap();
+
+        let parser = FixupParser::new(FixupMode::Apply, temp_dir.path().to_path_buf()).unwrap();
+        let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/no_newline.txt
++++ b/no_newline.txt
+@@ -1 +1 @@
+-old
+\ No newline at end of file
++new
+\ No newline at end of file
+```
+"#;
+
+        let diffs = parser.parse_diffs(content).unwrap();
+        let result = parser.apply_changes(&diffs).unwrap();
+
+        assert_eq!(result.applied_files.len(), 1);
+        assert!(result.failed_files.is_empty());
+        assert_eq!(std::fs::read_to_string(target_file).unwrap(), "new");
+    }
+
+    #[test]
+    fn apply_diff_keeps_newline_when_marker_only_describes_old_line() {
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("adds_newline.txt");
+        std::fs::write(&target_file, "old").unwrap();
+
+        let parser = FixupParser::new(FixupMode::Apply, temp_dir.path().to_path_buf()).unwrap();
+        let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/adds_newline.txt
++++ b/adds_newline.txt
+@@ -1 +1 @@
+-old
+\ No newline at end of file
++new
+```
+"#;
+
+        let diffs = parser.parse_diffs(content).unwrap();
+        let result = parser.apply_changes(&diffs).unwrap();
+
+        assert_eq!(result.applied_files.len(), 1);
+        assert!(result.failed_files.is_empty());
+        assert_eq!(std::fs::read_to_string(target_file).unwrap(), "new\n");
     }
 }

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -323,7 +323,7 @@ impl PacketBuilder {
         let mut upstream_results = Vec::new();
         let mut other_results = Vec::new();
 
-        for (candidate, result) in candidates.iter().zip(process_results.into_iter()) {
+        for (candidate, result) in candidates.iter().zip(process_results) {
             if candidate.priority == Priority::Upstream {
                 upstream_results.push((candidate, result));
             } else {

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -97,7 +97,7 @@ impl ReceiptManager {
         }
 
         // Sort by emitted_at timestamp
-        receipts.sort_by(|a, b| a.emitted_at.cmp(&b.emitted_at));
+        receipts.sort_by_key(|receipt| receipt.emitted_at);
 
         Ok(receipts)
     }

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -462,7 +462,7 @@ impl SecretRedactor {
             .collect();
 
         // Sort by ID for deterministic behavior
-        all_patterns.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
+        all_patterns.sort_by_key(|(id, _)| *id);
 
         for (id, regex) in all_patterns {
             if self.is_pattern_ignored(id) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(


### PR DESCRIPTION
### Motivation
- Unified diff metadata `\ No newline at end of file` was being treated as regular hunk lines which could break hunk matching and produce incorrect trailing-newline behavior when applying fixups. 
- Add regression tests to cover the two important edge cases: replacing a file that lacks a trailing newline, and adding a newline when the marker only described the old file. 
- While validating the changes, a few compile/clippy issues and a missing derive were discovered and fixed to keep the workspace clean. 

### Description
- Exclude the no-newline marker from hunk context extraction and hunk application logic so it does not participate in matching or content edits (`crates/xchecker-engine/src/fixup/apply.rs`).
- Preserve the new file's trailing-newline state by detecting no-newline markers and conditionally appending a final newline when writing reconstructed content (`diff_new_content_has_trailing_newline`, `is_no_newline_marker`).
- Add two white-box regression tests covering replacement with no-newline markers and marker-only-for-old-line behavior (tests in `crates/xchecker-engine/src/fixup/apply.rs`).
- Derive `PartialEq`/`Eq` for `DriftPair` so `Option<DriftPair>` fields can participate in derived equality for `FlowLockDrift` and related tests (`crates/xchecker-lock/src/lib.rs`).
- Fix minor clippy/style issues discovered during validation: replace `sort_by` with `sort_by_key` in redaction and receipt code, remove an unnecessary `.into_iter()` in packet builder, and tighten CLI formatting (small rustfmt and iteration cleanups). Files touched: `crates/xchecker-engine/src/fixup/apply.rs`, `crates/xchecker-lock/src/lib.rs`, `crates/xchecker-packet/src/builder.rs`, `crates/xchecker-receipt/src/writer.rs`, `crates/xchecker-redaction/src/lib.rs`, and a tiny CLI formatting tweak in `src/cli.rs`.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran `cargo test -p xchecker-engine fixup::apply --lib`, which passed (all new and existing fixup tests OK).
- Ran `cargo test -p xchecker-lock --lib`, which passed (lock crate tests OK after deriving `PartialEq`/`Eq`).
- Ran `cargo clippy -p xchecker-engine --lib -- -D warnings && cargo clippy -p xchecker-lock --lib -- -D warnings`, which passed after the addressed lints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ea60dc8333894c20df4c2d03ab)