### PR TITLE
Harden fixup diff parsing and fuzzy-apply edge cases

### DIFF
--- a/crates/xchecker-engine/src/fixup/apply.rs
+++ b/crates/xchecker-engine/src/fixup/apply.rs
@@ -368,11 +368,26 @@ impl FixupParser {
                     file_idx += 1;
                     additions += 1;
                 } else if line.starts_with('-') && !line.starts_with("---") {
-                    // Remove line
-                    if file_idx < lines.len() {
-                        lines.remove(file_idx);
-                        deletions += 1;
+                    // Remove line only when the current file line matches the
+                    // diff's expected old line. Fuzzy matching can choose a
+                    // nearby context with a high score; this guard prevents a
+                    // partial match from deleting unrelated content.
+                    let expected_old_line = &line[1..];
+                    if file_idx >= lines.len()
+                        || !self.lines_match(&lines[file_idx], expected_old_line)
+                    {
+                        return Err(FixupError::DiffParsingFailed {
+                            reason: format!(
+                                "Hunk for '{}' expected to remove '{}' at line {}, but found '{}'",
+                                diff.target_file,
+                                expected_old_line,
+                                file_idx + 1,
+                                lines.get(file_idx).map_or("<end of file>", String::as_str)
+                            ),
+                        });
                     }
+                    lines.remove(file_idx);
+                    deletions += 1;
                 } else if line.starts_with(' ') {
                     // Context line - just advance
                     file_idx += 1;

--- a/crates/xchecker-engine/src/fixup/match_context.rs
+++ b/crates/xchecker-engine/src/fixup/match_context.rs
@@ -82,7 +82,7 @@ impl FixupParser {
     }
 
     /// Compare two lines with whitespace normalization
-    fn lines_match(&self, file_line: &str, context_line: &str) -> bool {
+    pub(super) fn lines_match(&self, file_line: &str, context_line: &str) -> bool {
         // Exact match
         if file_line == context_line {
             return true;

--- a/crates/xchecker-engine/src/fixup/parse.rs
+++ b/crates/xchecker-engine/src/fixup/parse.rs
@@ -168,9 +168,10 @@ impl FixupParser {
     fn extract_diff_blocks(&self, content: &str) -> Result<Vec<UnifiedDiff>, FixupError> {
         let mut diffs = Vec::new();
 
-        // Regex to match fenced diff blocks: ```diff ... ```
-        // Use (?s) flag to make . match newlines
-        let diff_block_regex = Regex::new(r"(?s)```diff\n(.*?)\n```").unwrap();
+        // Regex to match fenced diff blocks like ```diff ... ```. Be lenient about
+        // common markdown/LLM variants: CRLF line endings, leading/trailing spaces
+        // around the language tag, and mixed-case `diff`.
+        let diff_block_regex = Regex::new(r"(?is)```[ \t]*diff[ \t]*\r?\n(.*?)\r?\n```").unwrap();
 
         for (block_index, captures) in diff_block_regex.captures_iter(content).enumerate() {
             let diff_content = captures
@@ -230,19 +231,21 @@ impl FixupParser {
                 reason: "No --- or +++ headers found".to_string(),
             })?;
 
-        // Remove a/ and b/ prefixes if present (common in git diffs)
-        let target_file = if target_file.starts_with("a/") || target_file.starts_with("b/") {
-            &target_file[2..]
-        } else {
-            target_file
-        };
+        let target_file = normalize_diff_header_path(target_file);
 
         // Parse hunks
         let hunks = self.parse_hunks(&lines[header_end..], block_index)?;
 
+        if hunks.is_empty() {
+            return Err(FixupError::InvalidDiffFormat {
+                block_index,
+                reason: "No hunk headers found".to_string(),
+            });
+        }
+
         Ok(UnifiedDiff {
-            path: target_file.to_string(),
-            target_file: target_file.to_string(),
+            path: target_file.clone(),
+            target_file,
             diff_content: diff_content.to_string(),
             hunks,
         })
@@ -336,6 +339,20 @@ impl FixupParser {
         }
 
         Ok(hunks)
+    }
+}
+
+fn normalize_diff_header_path(path: &str) -> String {
+    // Unified diff headers may append metadata after a tab, for example:
+    // `--- a/file.rs\t2026-05-16 00:00:00`. Keep spaces intact so paths
+    // containing spaces are not truncated.
+    let path = path.split('\t').next().unwrap_or(path).trim();
+
+    // Remove a/ and b/ prefixes if present (common in git diffs).
+    if path.starts_with("a/") || path.starts_with("b/") {
+        path[2..].to_string()
+    } else {
+        path.to_string()
     }
 }
 
@@ -580,9 +597,9 @@ some content
 ```
 "#;
 
-        let diffs = parser.parse_diffs(content).unwrap();
-        assert_eq!(diffs.len(), 1);
-        assert_eq!(diffs[0].hunks.len(), 0);
+        let result = parser.parse_diffs(content);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), FixupError::NoValidDiffBlocks));
     }
 
     #[test]

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(

--- a/tests/test_fixup_fuzzy_edge_cases.rs
+++ b/tests/test_fixup_fuzzy_edge_cases.rs
@@ -766,6 +766,99 @@ FIXUP PLAN:
     assert!(new_content.contains("added second"));
 }
 
+/// Test: diff fences may use CRLF line endings and whitespace around language tag.
+#[test]
+fn test_parse_diff_fence_with_crlf_and_spaced_language_tag() {
+    let (_temp_dir, base_dir) = setup_test_env();
+    let parser = FixupParser::new(FixupMode::Preview, base_dir.clone()).unwrap();
+
+    let content = "FIXUP PLAN:\r\n\r\n``` diff \r\n--- a/crlf.txt\r\n+++ b/crlf.txt\r\n@@ -1,1 +1,2 @@\r\n line 1\r\n+line 2\r\n```\r\n";
+
+    let diffs = parser.parse_diffs(content).unwrap();
+    assert_eq!(diffs.len(), 1);
+    assert_eq!(diffs[0].target_file, "crlf.txt");
+    assert_eq!(diffs[0].hunks.len(), 1);
+}
+
+/// Test: unified diff headers may include tab-separated timestamps.
+#[test]
+fn test_parse_diff_header_strips_tab_separated_metadata() {
+    let (_temp_dir, base_dir) = setup_test_env();
+    let parser = FixupParser::new(FixupMode::Preview, base_dir.clone()).unwrap();
+
+    let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/src/file with spaces.rs	2026-05-16 00:00:00.000000000 +0000
++++ b/src/file with spaces.rs	2026-05-16 00:00:01.000000000 +0000
+@@ -1,1 +1,2 @@
+ line 1
++line 2
+```
+"#;
+
+    let diffs = parser.parse_diffs(content).unwrap();
+    assert_eq!(diffs[0].target_file, "src/file with spaces.rs");
+}
+
+/// Test: header-only diff blocks are invalid instead of silently parsing as no-op diffs.
+#[test]
+fn test_parse_rejects_header_only_diff_block() {
+    let (_temp_dir, base_dir) = setup_test_env();
+    let parser = FixupParser::new(FixupMode::Preview, base_dir.clone()).unwrap();
+
+    let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/noop.txt
++++ b/noop.txt
+```
+"#;
+
+    let result = parser.parse_diffs(content);
+    assert!(
+        result.is_err(),
+        "header-only diff should not parse as a valid diff"
+    );
+}
+
+/// Test: fuzzy matching must not delete an unrelated line when surrounding context mostly matches.
+#[test]
+fn test_partial_fuzzy_match_does_not_delete_mismatched_old_line() {
+    let (_temp_dir, base_dir) = setup_test_env();
+
+    let test_file = base_dir.join("partial_match.txt");
+    let original_content = "alpha\nbeta\nactual target\ndelta\nepsilon\n";
+    fs::write(&test_file, original_content).unwrap();
+
+    let parser = FixupParser::new(FixupMode::Apply, base_dir.clone()).unwrap();
+
+    let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/partial_match.txt
++++ b/partial_match.txt
+@@ -1,5 +1,5 @@
+ alpha
+ beta
+-expected target
++replacement target
+ delta
+ epsilon
+```
+"#;
+
+    let diffs = parser.parse_diffs(content).unwrap();
+    let result = parser.apply_changes(&diffs).unwrap();
+
+    assert_eq!(result.failed_files, vec!["partial_match.txt".to_string()]);
+    let new_content = fs::read_to_string(&test_file).unwrap();
+    assert_eq!(new_content, original_content);
+}
+
 /// Test: Verify FuzzyMatchFailed error contains useful information
 #[test]
 fn test_fuzzy_match_failed_error_message() {


### PR DESCRIPTION
### Motivation
- Improve robustness of the fixup subsystem to handle real-world LLM/markdown diff variants and prevent unsafe file mutations. 
- Add tests that capture edge cases observed during red-green-refactor work around diff fences, header metadata, and fuzzy matching pitfalls. 
- Ensure lockfile drift model implements equality so existing equality checks remain correct. 

### Description
- Made diff-fence parsing more tolerant by updating the regex used in `extract_diff_blocks` to accept mixed-case `diff`, optional whitespace around the language tag, and CRLF line endings (change located in `crates/xchecker-engine/src/fixup/parse.rs`).
- Added `normalize_diff_header_path` to strip tab-separated metadata and normalize `a/`/`b/` prefixes when extracting target paths from `---/+++` headers in `parse_unified_diff` (`parse.rs`).
- Treat header-only or hunk-less diff blocks as invalid by returning `NoValidDiffBlocks` instead of silently producing empty hunks (`parse.rs`).
- Hardened application logic so deletions in `apply_diff_to_content` verify the expected old line before removing it, preventing fuzzy matches from deleting unrelated content (`crates/xchecker-engine/src/fixup/apply.rs`).
- Exposed the line-comparison helper as `pub(super) fn lines_match` to allow the deletion guard to call the same normalization logic (`crates/xchecker-engine/src/fixup/match_context.rs`).
- Added `PartialEq`/`Eq` derives to `DriftPair` so `FlowLockDrift` equality checks compile and behave as expected (`crates/xchecker-lock/src/lib.rs`).
- Added a suite of new and extended tests covering CRLF/spaced diff fences, tab-separated header metadata, header-only diffs, and safety around partial fuzzy matches (`tests/test_fixup_fuzzy_edge_cases.rs`).
- Minor formatting adjustments applied where needed to satisfy `cargo fmt` (`src/cli.rs`).

### Testing
- Ran `cargo fmt -- --check` which succeeded. 
- Ran `cargo test --test test_fixup_fuzzy_edge_cases -- --nocapture` and the new/modified fixup fuzzy-edge tests passed (`16 passed, 0 failed, 7 ignored`).
- Ran `cargo test -p xchecker-engine fixup --lib` and engine unit tests for the fixup module passed (`22 passed, 0 failed`).
- Ran `cargo test -p xchecker-lock` and lock crate tests passed (`56 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ea60dc8333894c20df4c2d03ab)