### PR TITLE
Harden fixup diff edge cases

### DIFF
--- a/crates/xchecker-engine/src/fixup/apply.rs
+++ b/crates/xchecker-engine/src/fixup/apply.rs
@@ -297,11 +297,11 @@ impl FixupParser {
                 .filter(|line| {
                     // Include context lines (starting with ' ') and removed lines (starting with '-')
                     // but NOT added lines (starting with '+') as those don't exist in the original file
-                    line.starts_with(' ')
-                        || line.starts_with('-')
-                        || (!line.starts_with('+') && !line.starts_with("@@"))
+                    !is_no_newline_marker(line)
+                        && (line.starts_with(' ')
+                            || line.starts_with('-')
+                            || (!line.starts_with('+') && !line.starts_with("@@")))
                 })
-                .filter(|line| !line.starts_with("---")) // Exclude --- header
                 .map(|line| {
                     // Strip the prefix character (' ' or '-')
                     if line.starts_with(' ') || line.starts_with('-') {
@@ -357,18 +357,21 @@ impl FixupParser {
             while hunk_idx < hunk_lines.len() {
                 let line = hunk_lines[hunk_idx];
 
-                if line.starts_with('+') && !line.starts_with("+++") {
-                    // Add line
-                    let new_line = line[1..].to_string();
+                if is_no_newline_marker(line) {
+                    // Metadata emitted by unified diffs for files without a trailing newline.
+                    // It is not a file line and must not affect matching or output.
+                } else if let Some(new_line) = line.strip_prefix('+') {
+                    // Add line. File header lines are not present inside parsed hunk content, so
+                    // hunk lines like `+++literal` represent a real line beginning with `++`.
                     if file_idx <= lines.len() {
-                        lines.insert(file_idx, new_line);
+                        lines.insert(file_idx, new_line.to_string());
                     } else {
-                        lines.push(new_line);
+                        lines.push(new_line.to_string());
                     }
                     file_idx += 1;
                     additions += 1;
-                } else if line.starts_with('-') && !line.starts_with("---") {
-                    // Remove line
+                } else if line.starts_with('-') {
+                    // Remove line. Likewise, `---literal` in a hunk means remove `--literal`.
                     if file_idx < lines.len() {
                         lines.remove(file_idx);
                         deletions += 1;
@@ -604,9 +607,12 @@ impl FixupParser {
 
         for hunk in &diff.hunks {
             for line in hunk.content.lines() {
-                if line.starts_with('+') && !line.starts_with("+++") {
+                if is_no_newline_marker(line) {
+                    continue;
+                }
+                if line.starts_with('+') {
                     lines_added += 1;
-                } else if line.starts_with('-') && !line.starts_with("---") {
+                } else if line.starts_with('-') {
                     lines_removed += 1;
                 }
             }
@@ -614,6 +620,10 @@ impl FixupParser {
 
         (lines_added, lines_removed)
     }
+}
+
+fn is_no_newline_marker(line: &str) -> bool {
+    line == r"\ No newline at end of file"
 }
 
 /// Normalize line endings to LF (FR-FIX-010, FR-FS-004, FR-FS-005)
@@ -649,6 +659,60 @@ pub fn normalize_line_endings_for_diff(content: &str) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_apply_diff_handles_no_newline_marker() {
+        let temp_dir = TempDir::new().unwrap();
+        let parser = FixupParser::new(FixupMode::Apply, temp_dir.path().to_path_buf()).unwrap();
+
+        let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/test.txt
++++ b/test.txt
+@@ -1,2 +1,2 @@
+ one
+-two
++TWO
+\ No newline at end of file
+```
+"#;
+
+        let diffs = parser.parse_diffs(content).unwrap();
+        let updated = parser.apply_diff_to_content("one\ntwo", &diffs[0]).unwrap();
+
+        assert_eq!(updated, "one\nTWO\n");
+    }
+
+    #[test]
+    fn test_apply_diff_preserves_lines_that_look_like_diff_headers() {
+        let temp_dir = TempDir::new().unwrap();
+        let parser = FixupParser::new(FixupMode::Apply, temp_dir.path().to_path_buf()).unwrap();
+
+        let content = r#"
+FIXUP PLAN:
+
+```diff
+--- a/test.txt
++++ b/test.txt
+@@ -1,3 +1,3 @@
+ keep
+---old
++++new
+ end
+```
+"#;
+
+        let diffs = parser.parse_diffs(content).unwrap();
+        let updated = parser
+            .apply_diff_to_content("keep\n--old\nend\n", &diffs[0])
+            .unwrap();
+        let (added, removed) = parser.calculate_change_stats(&diffs[0]);
+
+        assert_eq!(updated, "keep\n++new\nend\n");
+        assert_eq!((added, removed), (1, 1));
+    }
 
     #[test]
     fn test_calculate_change_stats() {

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(


### PR DESCRIPTION
### Motivation
- Fixup application was fragile for certain unified-diff edge cases: the `\ No newline at end of file` metadata was treated as file content and some real file lines that begin with `++`/`--` were mistaken for diff file headers.
- Add regression coverage and defensive parsing so fixups can be reliably previewed and applied in the presence of these diff artifacts.
- Ensure lockfile types used for equality comparisons derive the required traits so the workspace builds and tests compile cleanly.

### Description
- Ignore the unified-diff marker `\ No newline at end of file` when extracting context and when counting/applying hunk lines by adding the helper `is_no_newline_marker` and filtering it out from matching and stats logic in `FixupParser` (`crates/xchecker-engine/src/fixup/apply.rs`).
- Preserve real file lines that start with `++` or `--` by using `strip_prefix('+')` for added lines and treating `-` removals directly, avoiding false-positive header detection inside hunks (`crates/xchecker-engine/src/fixup/apply.rs`).
- Add two focused unit tests to cover the regressions: `test_apply_diff_handles_no_newline_marker` and `test_apply_diff_preserves_lines_that_look_like_diff_headers` in the fixup apply tests.
- Derive `PartialEq` and `Eq` for `DriftPair` so `FlowLockDrift` equality derives compile cleanly (`crates/xchecker-lock/src/lib.rs`).
- Run `rustfmt` and apply minor formatting cleanups in the CLI (`src/cli.rs`).

### Testing
- Ran the focused apply tests with `cargo test -p xchecker-engine apply_diff_ -- --nocapture` and the new tests passed. (succeeded)
- Ran lock crate tests with `cargo test -p xchecker-lock --lib` and engine crate tests with `cargo test -p xchecker-engine --lib`, both succeeded. (succeeded)
- Ran the full workspace suite with `cargo test --workspace --lib` and `cargo fmt -- --check` and observed the test run complete with all tests passing and formatting checks OK. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ea60dc8333894c20df4c2d03ab)