### PR TITLE
Improve config validation unit tests

### DIFF
--- a/crates/xchecker-config/src/config/validation.rs
+++ b/crates/xchecker-config/src/config/validation.rs
@@ -306,3 +306,130 @@ impl Config {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AnthropicConfig, Config, OpenRouterConfig};
+
+    fn valid_config() -> Config {
+        let mut config = Config::minimal_for_testing();
+        config.llm.provider = Some("claude-cli".to_string());
+        config.llm.execution_strategy = Some("controlled".to_string());
+        config
+    }
+
+    fn invalid_key(result: Result<(), XCheckerError>) -> String {
+        match result.expect_err("configuration should be invalid") {
+            XCheckerError::Config(ConfigError::InvalidValue { key, .. }) => key,
+            XCheckerError::Config(ConfigError::MissingRequired(key)) => key,
+            other => panic!("expected config validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validation_accepts_documented_numeric_boundaries() {
+        let mut config = valid_config();
+        config.defaults.packet_max_bytes = Some(1);
+        config.defaults.packet_max_lines = Some(1);
+        config.defaults.max_turns = Some(1);
+        config.defaults.phase_timeout = Some(5);
+        config.defaults.stdout_cap_bytes = Some(1024);
+        config.defaults.stderr_cap_bytes = Some(1024);
+        config.defaults.lock_ttl_seconds = Some(60);
+        config.validate().unwrap();
+
+        config.defaults.packet_max_bytes = Some(10_000_000);
+        config.defaults.packet_max_lines = Some(100_000);
+        config.defaults.max_turns = Some(50);
+        config.defaults.phase_timeout = Some(7200);
+        config.defaults.stdout_cap_bytes = Some(100_000_000);
+        config.defaults.stderr_cap_bytes = Some(10_000_000);
+        config.defaults.lock_ttl_seconds = Some(86_400);
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn validation_rejects_numeric_values_outside_documented_boundaries() {
+        macro_rules! assert_invalid_default {
+            ($expected_key:literal, $field:ident, $value:expr) => {{
+                let mut config = valid_config();
+                config.defaults.$field = Some($value);
+                assert_eq!(invalid_key(config.validate()), $expected_key);
+            }};
+        }
+
+        assert_invalid_default!("packet_max_bytes", packet_max_bytes, 0);
+        assert_invalid_default!("packet_max_bytes", packet_max_bytes, 10_000_001);
+        assert_invalid_default!("packet_max_lines", packet_max_lines, 0);
+        assert_invalid_default!("packet_max_lines", packet_max_lines, 100_001);
+        assert_invalid_default!("max_turns", max_turns, 0);
+        assert_invalid_default!("max_turns", max_turns, 51);
+        assert_invalid_default!("phase_timeout", phase_timeout, 4);
+        assert_invalid_default!("phase_timeout", phase_timeout, 7201);
+        assert_invalid_default!("stdout_cap_bytes", stdout_cap_bytes, 1023);
+        assert_invalid_default!("stdout_cap_bytes", stdout_cap_bytes, 100_000_001);
+        assert_invalid_default!("stderr_cap_bytes", stderr_cap_bytes, 1023);
+        assert_invalid_default!("stderr_cap_bytes", stderr_cap_bytes, 10_000_001);
+        assert_invalid_default!("lock_ttl_seconds", lock_ttl_seconds, 59);
+        assert_invalid_default!("lock_ttl_seconds", lock_ttl_seconds, 86_401);
+    }
+
+    #[test]
+    fn validation_requires_models_for_http_primary_providers() {
+        let mut openrouter = valid_config();
+        openrouter.llm.provider = Some("openrouter".to_string());
+        assert_eq!(invalid_key(openrouter.validate()), "llm.openrouter.model");
+
+        openrouter.llm.openrouter = Some(OpenRouterConfig {
+            api_key_env: None,
+            base_url: None,
+            model: Some(String::new()),
+            max_tokens: None,
+            temperature: None,
+            budget: None,
+        });
+        assert_eq!(invalid_key(openrouter.validate()), "llm.openrouter.model");
+
+        openrouter.llm.openrouter.as_mut().unwrap().model = Some("openai/gpt-5.1".to_string());
+        openrouter.validate().unwrap();
+
+        let mut anthropic = valid_config();
+        anthropic.llm.provider = Some("anthropic".to_string());
+        assert_eq!(invalid_key(anthropic.validate()), "llm.anthropic.model");
+
+        anthropic.llm.anthropic = Some(AnthropicConfig {
+            api_key_env: None,
+            base_url: None,
+            model: Some("claude-sonnet-4-5".to_string()),
+            max_tokens: None,
+            temperature: None,
+        });
+        anthropic.validate().unwrap();
+    }
+
+    #[test]
+    fn validation_requires_models_for_http_fallback_providers() {
+        let mut config = valid_config();
+        config.llm.fallback_provider = Some("anthropic".to_string());
+        assert_eq!(invalid_key(config.validate()), "llm.anthropic.model");
+
+        config.llm.anthropic = Some(AnthropicConfig {
+            api_key_env: None,
+            base_url: None,
+            model: Some("claude-haiku-4-5".to_string()),
+            max_tokens: None,
+            temperature: None,
+        });
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn validation_checks_prompt_template_against_fallback_provider() {
+        let mut config = valid_config();
+        config.llm.prompt_template = Some("claude-optimized".to_string());
+        config.llm.fallback_provider = Some("gemini-cli".to_string());
+
+        assert_eq!(invalid_key(config.validate()), "llm.prompt_template");
+    }
+}

--- a/crates/xchecker-lock/src/lib.rs
+++ b/crates/xchecker-lock/src/lib.rs
@@ -157,7 +157,7 @@ pub struct PromotionLock {
 }
 
 /// Drift pair showing locked vs current value
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DriftPair {
     /// Value from lockfile
     pub locked: String,
@@ -1788,7 +1788,9 @@ mod tests {
         requirements.parent_receipt_path = Some("receipts/requirements.json".to_string());
         requirements.parent_packet_lineage = vec!["packet-req-1".to_string()];
         requirements.warnings = vec!["minor-style-warning".to_string()];
-        requirements.save().expect("Failed to save requirements promotion");
+        requirements
+            .save()
+            .expect("Failed to save requirements promotion");
 
         let mut design = PromotionLock::new(
             spec_id.to_string(),
@@ -1801,7 +1803,8 @@ mod tests {
             }],
         );
         design.approved_by = Some("policy-engine".to_string());
-        design.parent_packet_lineage = vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
+        design.parent_packet_lineage =
+            vec!["packet-req-1".to_string(), "packet-design-1".to_string()];
         design.save().expect("Failed to save design promotion");
 
         let loaded = PromotionLock::load(spec_id, "requirements")

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -323,7 +323,7 @@ impl PacketBuilder {
         let mut upstream_results = Vec::new();
         let mut other_results = Vec::new();
 
-        for (candidate, result) in candidates.iter().zip(process_results.into_iter()) {
+        for (candidate, result) in candidates.iter().zip(process_results) {
             if candidate.priority == Priority::Upstream {
                 upstream_results.push((candidate, result));
             } else {

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -97,7 +97,7 @@ impl ReceiptManager {
         }
 
         // Sort by emitted_at timestamp
-        receipts.sort_by(|a, b| a.emitted_at.cmp(&b.emitted_at));
+        receipts.sort_by_key(|receipt| receipt.emitted_at);
 
         Ok(receipts)
     }

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -462,7 +462,7 @@ impl SecretRedactor {
             .collect();
 
         // Sort by ID for deterministic behavior
-        all_patterns.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
+        all_patterns.sort_by_key(|(id, _)| *id);
 
         for (id, regex) in all_patterns {
             if self.is_pattern_ignored(id) {

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -307,25 +307,17 @@ where
         {
             match key.code {
                 KeyCode::Char('q') => return Ok(()),
-                KeyCode::Up | KeyCode::Char('k') => {
-                    if !app.show_details {
-                        app.select_previous();
-                    }
+                KeyCode::Up | KeyCode::Char('k') if !app.show_details => {
+                    app.select_previous();
                 }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    if !app.show_details {
-                        app.select_next();
-                    }
+                KeyCode::Down | KeyCode::Char('j') if !app.show_details => {
+                    app.select_next();
                 }
-                KeyCode::Home => {
-                    if !app.show_details {
-                        app.select_first();
-                    }
+                KeyCode::Home if !app.show_details => {
+                    app.select_first();
                 }
-                KeyCode::End => {
-                    if !app.show_details {
-                        app.select_last();
-                    }
+                KeyCode::End if !app.show_details => {
+                    app.select_last();
                 }
                 KeyCode::Enter => app.toggle_details(),
                 KeyCode::Esc => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3021,7 +3021,6 @@ fn execute_init_command(spec_id: &str, create_lock: bool, config: &Config) -> Re
     // Check if spec already exists
     if spec_dir.exists() {
         println!("  Spec directory already exists: {}", spec_dir.display());
-
     } else {
         // Create directory structure (ignore benign races)
         crate::paths::ensure_dir_all(&artifacts_dir).with_context(|| {
@@ -3252,10 +3251,7 @@ fn check_lockfile_drift(
             );
         }
         if let Some(gate_set) = &drift.gate_set_version {
-            eprintln!(
-                "  Gate set: {} → {}",
-                gate_set.locked, gate_set.current
-            );
+            eprintln!("  Gate set: {} → {}", gate_set.locked, gate_set.current);
         }
         if let Some(prompt_pack) = &drift.prompt_pack_version {
             eprintln!(

--- a/tests/doc_validation/code_examples_tests.rs
+++ b/tests/doc_validation/code_examples_tests.rs
@@ -730,10 +730,8 @@ impl ScanState {
             '\'' => self.in_single = true,
             '"' => self.in_double = true,
             '(' => self.paren_depth += 1,
-            ')' => {
-                if self.paren_depth > 0 {
-                    self.paren_depth -= 1;
-                }
+            ')' if self.paren_depth > 0 => {
+                self.paren_depth -= 1;
             }
             _ => {}
         }

--- a/tests/integration_full_workflows.rs
+++ b/tests/integration_full_workflows.rs
@@ -575,7 +575,7 @@ async fn test_multi_phase_workflow_with_dependencies() -> Result<()> {
     }
 
     // Sort by emitted_at timestamp
-    receipts.sort_by(|a, b| a.emitted_at.cmp(&b.emitted_at));
+    receipts.sort_by_key(|receipt| receipt.emitted_at);
 
     assert_eq!(
         receipts[0].phase, "requirements",


### PR DESCRIPTION
### Motivation
- Improve unit coverage for `Config::validate()` to ensure numeric boundaries, HTTP provider model requirements, and prompt-template/provider compatibility are enforced by tests.
- Fix a compilation issue where `FlowLockDrift` equality derivation required `DriftPair` to implement `PartialEq`/`Eq`.
- Address Clippy suggestions and small style issues discovered while running the workspace lint/test pipeline to keep the repo lint-clean.

### Description
- Add focused unit tests in `crates/xchecker-config/src/config/validation.rs` covering valid boundaries, out-of-range rejections, HTTP primary/fallback provider model requirements, and prompt-template compatibility checks.
- Derive `PartialEq` and `Eq` for `DriftPair` in `crates/xchecker-lock/src/lib.rs` so `FlowLockDrift` can derive equality cleanly.
- Apply clippy-driven simplifications: replace `.sort_by(|..| ..)` with `sort_by_key` in `crates/xchecker-redaction` and `crates/xchecker-receipt`, remove an unnecessary `.into_iter()` in `crates/xchecker-packet`, and convert nested `if` matches to match-guards in `crates/xchecker-tui` and a parser test.
- Run `cargo fmt` which normalized minor CLI/lock test formatting touched by the changes.

### Testing
- Ran `cargo test -p xchecker-config --lib` and the new/updated `xchecker-config` unit tests passed (all tests green).
- Ran `cargo clippy --workspace --all-targets --all-features -- -D warnings` and addressed reported lints so the workspace is lint-clean.
- Ran `cargo test --workspace --lib --bins` and the workspace test suite completed successfully.
- Ran `cargo fmt -- --check && git diff --check` to verify formatting and no diff-check issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1da8cf08333a5d44c8cea7b6c21)